### PR TITLE
fix: handle reset button action

### DIFF
--- a/blocks/form/components/file.js
+++ b/blocks/form/components/file.js
@@ -256,10 +256,6 @@ export default async function decorate(fieldDiv, field, htmlForm) {
       fileHandler.previewFile(e.target?.parentElement?.dataset?.index || 0);
     }
   });
-  htmlForm.addEventListener('reset', () => {
-    fileListElement.innerHTML = '';
-    input.value = '';
-  });
   fieldDiv.insertBefore(fileListElement, input.nextElementSibling);
   // pre-fill file attachment
   if (field.value) {

--- a/blocks/form/components/wizard.js
+++ b/blocks/form/components/wizard.js
@@ -152,6 +152,11 @@ export class WizardLayout {
       });
     }
 
+    const resetBtn = panel.querySelector('.reset-wrapper');
+    if (resetBtn) {
+      wrapper.append(resetBtn);
+    }
+
     const submitBtn = panel.querySelector('.submit-wrapper');
     if (submitBtn) {
       wrapper.append(submitBtn);

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -407,12 +407,13 @@ export async function createForm(formDef, data) {
   if (afModule) {
     window.setTimeout(async () => {
       afModule.loadRuleEngine(formDef, form, captcha, generateFormRendition, data);
-      form.addEventListener('reset', async () => {
-        const newForm = await createForm(formDef);
-        document.querySelector(`[data-action="${formDef.action}"]`).replaceWith(newForm);
-      });
     }, DELAY_MS);
   }
+
+  form.addEventListener('reset', async () => {
+    const newForm = await createForm(formDef);
+    document.querySelector(`[data-action="${formDef.action}"]`).replaceWith(newForm);
+  });
 
   form.addEventListener('submit', (e) => {
     handleSubmit(e, form, captcha);

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -407,6 +407,10 @@ export async function createForm(formDef, data) {
   if (afModule) {
     window.setTimeout(async () => {
       afModule.loadRuleEngine(formDef, form, captcha, generateFormRendition, data);
+      form.addEventListener('reset', async () => {
+        const newForm = await createForm(formDef);
+        document.querySelector(`[data-action="${formDef.action}"]`).replaceWith(newForm);
+      });
     }, DELAY_MS);
   }
 

--- a/blocks/form/util.js
+++ b/blocks/form/util.js
@@ -105,13 +105,10 @@ export function createButton(fd) {
   button.textContent = fd?.label?.visible === false ? '' : fd?.label?.value;
   button.type = fd.buttonType || 'button';
   button.classList.add('button');
-  const clickEvent = fd?.events?.click;
-  if (button.type === 'button' && clickEvent && Array.isArray(clickEvent)) {
-    if (clickEvent.some((event) => event.includes("dispatchEvent('reset')"))) {
-      button.type = 'reset';
-    } else if (clickEvent.some((event) => event.includes('submitForm'))) {
-      button.type = 'submit';
-    }
+  if (fd.buttonType === 'submit') {
+    button.type = 'submit';
+  } else if (fd.buttonType === 'reset') {
+    button.type = 'reset';
   }
   button.id = fd.id;
   button.name = fd.name;

--- a/blocks/form/util.js
+++ b/blocks/form/util.js
@@ -105,11 +105,6 @@ export function createButton(fd) {
   button.textContent = fd?.label?.visible === false ? '' : fd?.label?.value;
   button.type = fd.buttonType || 'button';
   button.classList.add('button');
-  if (fd.buttonType === 'submit') {
-    button.type = 'submit';
-  } else if (fd.buttonType === 'reset') {
-    button.type = 'reset';
-  }
   button.id = fd.id;
   button.name = fd.name;
   if (fd?.label?.visible === false) {

--- a/blocks/form/util.js
+++ b/blocks/form/util.js
@@ -105,6 +105,14 @@ export function createButton(fd) {
   button.textContent = fd?.label?.visible === false ? '' : fd?.label?.value;
   button.type = fd.buttonType || 'button';
   button.classList.add('button');
+  const clickEvent = fd.events?.click[0];
+  if (button.type === 'button' && clickEvent) {
+    if (clickEvent.includes("dispatchEvent('reset')")) {
+      button.type = 'reset';
+    } else if (clickEvent.includes('submitForm()')) {
+      button.type = 'submit';
+    }
+  }
   button.id = fd.id;
   button.name = fd.name;
   if (fd?.label?.visible === false) {

--- a/blocks/form/util.js
+++ b/blocks/form/util.js
@@ -105,11 +105,11 @@ export function createButton(fd) {
   button.textContent = fd?.label?.visible === false ? '' : fd?.label?.value;
   button.type = fd.buttonType || 'button';
   button.classList.add('button');
-  const clickEvent = fd.events?.click[0];
-  if (button.type === 'button' && clickEvent) {
-    if (clickEvent.includes("dispatchEvent('reset')")) {
+  const clickEvent = fd?.events?.click;
+  if (button.type === 'button' && clickEvent && Array.isArray(clickEvent)) {
+    if (clickEvent.some((event) => event.includes("dispatchEvent('reset')"))) {
       button.type = 'reset';
-    } else if (clickEvent.includes('submitForm()')) {
+    } else if (clickEvent.some((event) => event.includes('submitForm'))) {
       button.type = 'submit';
     }
   }

--- a/test/fixtures/form/claim.html
+++ b/test/fixtures/form/claim.html
@@ -98,6 +98,16 @@
         <div class="number-wrapper field-your-e-mail-address1701932419752 field-wrapper" data-id="textinput-93659472e1" data-required="false"><label
                 for="textinput-93659472e1" class="field-label">Your E-mail Address</label><input type="number"
                 id="textinput-93659472e1" name="Your_E_mail_Address1701932419752" autocomplete="off"></div>
+        <div class="file-wrapper field-fileinput1713343980571 field-wrapper decorated" data-id="fileinput-9d805e9eca" data-required="false">
+                <label for="fileinput-9d805e9eca" class="field-label">Your ID</label>
+                <div class="file-drag-area">
+                  <div class="file-dragIcon"></div>
+                  <div class="file-dragText">Drag and Drop To Upload</div>
+                  <button class="file-attachButton" type="button">Attach</button>
+                  <input type="file" accept="audio/*, video/*, image/*, text/*, application/pdf" id="fileinput-9d805e9eca" name="fileinput1713343980571" autocomplete="off" data-max-file-size="2MB">
+                </div>
+                <div class="files-list"></div>
+        </div>
     </fieldset>
     <fieldset class="panel-wrapper field-panel-2 field-wrapper" data-id="panelcontainer-eff9c5f6ff" id="panelcontainer-eff9c5f6ff" name="panel_2"
         data-index="1" style="--wizard-step-index: 1;">
@@ -304,5 +314,7 @@
                 class="button" id="wizard-button-prev" name="back">Back</button></div>
         <div class="button-wrapper field-next field-wrapper wizard-button-next" data-id="wizard-button-next"><button type="button"
                 class="button" id="wizard-button-next" name="next">Next</button></div>
+        <div class="button-wrapper field-reset1713344016774 field-wrapper reset-wrapper" data-id="reset-0d74964a9e">
+                <button type="reset" class="button" id="reset-0d74964a9e" name="reset1713344016774">Reset</button></div>
     </div>
 </fieldset>

--- a/test/fixtures/form/claim.js
+++ b/test/fixtures/form/claim.js
@@ -312,6 +312,31 @@ export const fieldDef = {
               },
               ':type': 'formsninja/components/adaptiveForm/textinput',
             },
+            {
+              id: 'fileinput-9d805e9eca',
+              fieldType: 'file-input',
+              name: 'fileinput1713343980571',
+              type: 'file',
+              accept: [
+                'audio/*',
+                ' video/*',
+                ' image/*',
+                ' text/*',
+                ' application/pdf'
+              ],
+              properties: {
+                dragDropText: 'Drag and drop to Upload'
+              },
+              label: {
+                value: 'Your ID'
+              },
+              events: {
+                'custom:setProperty': [
+                  '$event.payload'
+                ]
+              },
+              ":type": "formsninja/components/adaptiveForm/fileinput"
+            },
           ],
         },
         {
@@ -534,6 +559,28 @@ export const fieldDef = {
                 ],
               },
               ':type': 'formsninja/components/adaptiveForm/textinput',
+            },
+            {
+              id: 'reset-0d74964a9e',
+              fieldType: 'button',
+              name: 'reset1713344016774',
+              type: 'string',
+              buttonType: 'reset',
+              properties: {
+                'fd:buttonType': 'reset'
+              },
+              label: {
+                value: 'Reset'
+              },
+              events: {
+                click: [
+                  'dispatchEvent("reset")'
+                ],
+                'custom:setProperty': [
+                  '$event.payload'
+                ]
+              },
+              ":type": "formsninja/components/adaptiveForm/actions/reset"
             },
           ],
         },

--- a/test/fixtures/reset/successful-reset.js
+++ b/test/fixtures/reset/successful-reset.js
@@ -41,4 +41,5 @@ export function expect(block) {
   assert.equal(fileList.innerHTML.includes('file1.png'), false, 'Should not show file1.png');
 }
 
+
 export const refresh = true;

--- a/test/fixtures/reset/successful-reset.js
+++ b/test/fixtures/reset/successful-reset.js
@@ -1,0 +1,44 @@
+import assert from 'assert';
+
+import { fieldDef } from '../form/claim.js';
+import { setValue } from '../../testUtils.js';
+
+export const sample = fieldDef;
+
+export function op(block) {
+  setValue(block, '#textinput-5d4030d204', 'Aya Tan');
+  const input = block.querySelector('#fileinput-9d805e9eca');
+  const file1 = new File([new ArrayBuffer(1024)], 'file1.png', { type: 'image/png' });
+  const event = new Event('change', {
+    bubbles: true,
+    cancelable: true,
+  });
+  try {
+  input.files = [file1];
+  input.dispatchEvent(event);
+  const fileList = block.querySelector('.files-list');
+  assert.equal(fileList.children.length, 1, 'Should render file1');
+  assert.equal(fileList.innerHTML.includes('file1.png'), true, 'Should show file1.png');
+  } catch (e) {
+    console.log(e);
+  }
+  const nxt = block.querySelector('.wizard .field-next');
+  nxt.click();
+  const instances = block.querySelector('.wizard-menu-active-item');
+  assert.equal(instances?.dataset.index, 1);
+  const resetButton = block.querySelector('#reset-0d74964a9e');
+  resetButton.click();
+  const form = block.querySelector('form');
+  form.dispatchEvent(new Event('reset'));
+}
+
+export function expect(block) {
+  const instances = block.querySelector('.wizard-menu-active-item');
+  assert.equal(instances?.dataset.index, 0);
+  assert.equal(block.querySelector('#textinput-5d4030d204').value, '');
+  const fileList = block.querySelector('.files-list');
+  assert.equal(fileList.children.length, 0, 'Should not render file1');
+  assert.equal(fileList.innerHTML.includes('file1.png'), false, 'Should not show file1.png');
+}
+
+export const refresh = true;

--- a/test/render.test.js
+++ b/test/render.test.js
@@ -8,6 +8,7 @@ executeTestInFolder('./test/fixtures/components/text-input/', testBasicMarkup, t
 
 executeTestInFolder('./test/fixtures/form/');
 executeTestInFolder('./test/fixtures/dynamic/', testDynamism);
+executeTestInFolder('./test/fixtures/reset/', testDynamism);
 
 executeTestInFolder('./test/fixtures/submit/', testDynamism);
 executeTestInFolder('./test/fixtures/doc-based-submit/', testDynamism, true);

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -126,8 +126,9 @@ async function test(
   after = () => {},
   bUrlMode = false,
   formPath = '',
+  refresh = false,
 ) {
-  const block = bUrlMode ? createBlockWithUrl(sample, formPath) : createBlock(sample);
+  var block = bUrlMode ? createBlockWithUrl(sample, formPath) : createBlock(sample);
   before();
   // console.log('before');
   await decorate(block);
@@ -137,6 +138,10 @@ async function test(
     op(block);
   }, opDelay);
   // console.log('op');
+  if (refresh) {
+      block = bUrlMode ? createBlockWithUrl(sample, formPath) : createBlock(sample);
+      await decorate(block);
+  }
   await runAfterdelay(() => {
     // console.log('before expect');
     expect(block);
@@ -149,13 +154,13 @@ export async function testDynamism(filePath, bUrlMode = false) {
   const testName = `checking dynamic behaviour for ${filePath?.substr(filePath.lastIndexOf('/') + 1).split('.')[0]}`;
   it(testName, async () => {
     const {
-      sample, before, op, expect, opDelay, after, formPath, ignore = false,
+      sample, before, op, expect, opDelay, after, formPath, ignore = false, refresh = false,
     } = await import(filePath);
     if (ignore) {
       return;
     }
     resetIds();
-    await test(sample, before, op, expect, opDelay, after, bUrlMode, formPath);
+    await test(sample, before, op, expect, opDelay, after, bUrlMode, formPath, refresh);
   });
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix https://github.com/adobe-rnd/form-block/issues/210

On clicking reset, fixes following things:

- Switch to first panel.
- clear all file attachments.
- clear all repeatable components if created.
- Showing Reset button on all pages in wizard (similar to Submit)
- Removed reset event listener for file component. This wasn't working earlier anyway.

Test URLs:
- Before: https://main--aem-boilerplate-forms--ujjwal5.hlx.page/content/forms/af/ujjgupta/wizard-single
- After: https://bug-reset--aem-boilerplate-forms--ujjwal5.hlx.page/content/forms/af/ujjgupta/wizard-single
