### PR TITLE
Replace OOTB browser messages with constant strings

### DIFF
--- a/blocks/form/constant.js
+++ b/blocks/form/constant.js
@@ -8,6 +8,12 @@ export const defaultErrorMessages = {
   maxFileSize: 'File too large. Reduce size and try again.',
   maxItems: 'Specify a number of items equal to or less than $0.',
   minItems: 'Specify a number of items equal to or greater than $0.',
+  pattern: 'Specify the value in allowed format : $0.',
+  minLength: 'Please lengthen this text to $0 characters or more.',
+  maxLength: 'Please shorten this text to $0 characters or less.',
+  maximum: 'Value must be less than or equal to $0.',
+  minimum: 'Value must be greater than or equal to $0.',
+  required: 'Please fill in this field.',
 };
 
 // eslint-disable-next-line no-useless-escape

--- a/blocks/form/util.js
+++ b/blocks/form/util.js
@@ -1,4 +1,6 @@
 // create a string containing head tags from h1 to h5
+import { defaultErrorMessages } from './constant.js';
+
 const headings = Array.from({ length: 5 }, (_, i) => `<h${i + 1}>`).join('');
 const allowedTags = `${headings}<a><b><p><i><em><strong><ul><li>`;
 
@@ -172,12 +174,12 @@ function removeInvalidMsg(fieldElement) {
 }
 
 export const validityKeyMsgMap = {
-  patternMismatch: 'patternErrorMessage',
-  rangeOverflow: 'maximumErrorMessage',
-  rangeUnderflow: 'minimumErrorMessage',
-  tooLong: 'maxLengthErrorMessage',
-  tooShort: 'minLengthErrorMessage',
-  valueMissing: 'requiredErrorMessage',
+  patternMismatch: { key: 'pattern', attribute: 'type' },
+  rangeOverflow: { key: 'maximum', attribute: 'max' },
+  rangeUnderflow: { key: 'minimum', attribute: 'min' },
+  tooLong: { key: 'maxLength', attribute: 'maxlength' },
+  tooShort: { key: 'minLength', attribute: 'minlength' },
+  valueMissing: { key: 'required' },
 };
 
 export function getCheckboxGroupValue(name, htmlForm) {
@@ -202,6 +204,14 @@ function updateRequiredCheckboxGroup(name, htmlForm) {
   });
 }
 
+function getValidationMessage(fieldElement) {
+  const [invalidProperty] = Object.keys(validityKeyMsgMap)
+    .filter((state) => fieldElement.validity[state]);
+  const { key, attribute } = validityKeyMsgMap[invalidProperty] || {};
+  const message = attribute ? defaultErrorMessages[key].replace(/\$0/, fieldElement.getAttribute(attribute)) : defaultErrorMessages[key];
+  return message || fieldElement.validationMessage;
+}
+
 export function checkValidation(fieldElement) {
   const wrapper = fieldElement.closest('.field-wrapper');
   const isCheckboxGroup = fieldElement.dataset.fieldType === 'checkbox-group';
@@ -214,10 +224,6 @@ export function checkValidation(fieldElement) {
     return;
   }
 
-  const [invalidProperty] = Object.keys(validityKeyMsgMap)
-    .filter((state) => fieldElement.validity[state]);
-
-  const message = wrapper.dataset[validityKeyMsgMap[invalidProperty]]
-  || fieldElement.validationMessage;
+  const message = getValidationMessage(fieldElement);
   updateOrCreateInvalidMsg(fieldElement, message);
 }

--- a/test/fixtures/dynamic/error-messages.js
+++ b/test/fixtures/dynamic/error-messages.js
@@ -63,6 +63,15 @@ export const sample = {
       },
     },
     {
+      fieldType: 'email',
+      id: 'f6',
+      name: 'f6_text',
+      required: true,
+      constraintMessages: {
+        required: 'Please fill in this field.',
+      },
+    },
+    {
       fieldType: 'button',
       id: 'button',
       buttonType: 'submit',
@@ -85,15 +94,21 @@ export function expect(block) {
   const f1 = block.querySelector('#f1').parentElement;
   const f1Message = f1.querySelector('.field-invalid .field-description');
   assert.equal(f1Message.textContent, 'Please fill in this field.', 'Required error message for text input');
-  setValue(block, '#f1', 'a');
-  assert.equal(f1.querySelector('.field-description.field-invalid'), undefined, 'Not required error message for text input');
+  setValue(block, '#f1', 'abc');
+  assert.equal(f1.querySelector('.field-invalid .field-description'), undefined, 'Not Required error message for number input');
 
   // number input error message
   const f2 = block.querySelector('#f2').parentElement;
   const f2Message = f2.querySelector('.field-invalid .field-description');
   assert.equal(f2Message.textContent, 'Please fill in this field.', 'Required error message for number input');
+  setValue(block, '#f2', 5);
+  assert.equal(f2.querySelector('.field-invalid .field-description'), undefined, 'Not Required error message for number input');
   setValue(block, '#f2', 1);
-  assert.equal(f2Message.querySelector('.field-description.field-invalid'), undefined, 'Not Required error message for number input');
+  const minMessage = f2.querySelector('.field-invalid .field-description').textContent;
+  assert.equal(minMessage, 'Value must be greater than or equal to 2.', 'minimum error message for number input');
+  setValue(block, '#f2', 11);
+  const maxMessage = f2.querySelector('.field-invalid .field-description').textContent;
+  assert.equal(maxMessage, 'Value must be less than or equal to 10.', 'maximum error message for number input');
 
   // radio buttons error message
   const f3 = block.querySelector('#f3');
@@ -116,6 +131,7 @@ export function expect(block) {
   // file input error message
   const f5 = block.querySelector('#f5').closest('.field-wrapper');
   const f5Message = f5.querySelector('.field-invalid .field-description');
+  // eslint-disable-next-line max-len
   assert.equal(f5Message.textContent, 'Please fill in this field.', 'Required error message for file input');
   const input = block.querySelector('#f5');
   const file = new File([new ArrayBuffer(1024)], 'file1.png', { type: 'image/png' });
@@ -125,6 +141,13 @@ export function expect(block) {
   });
   event.files = [file];
   input.dispatchEvent(event);
+
+  // email input error message
+  const f6 = block.querySelector('#f6').closest('.field-wrapper');
+  const f6Message = f6.querySelector('.field-invalid .field-description');
+  assert.equal(f6Message.textContent, 'Please fill in this field.', 'Required error message for file input');
+  setValue(block, '#f6', 'abc');
+  assert.equal(f6.querySelector('.field-invalid .field-description').textContent, 'Specify the value in allowed format : email.', 'Invalid email error message');
 }
 
 export const opDelay = 100;

--- a/test/fixtures/dynamic/error-messages.js
+++ b/test/fixtures/dynamic/error-messages.js
@@ -95,7 +95,7 @@ export function expect(block) {
   const f1Message = f1.querySelector('.field-invalid .field-description');
   assert.equal(f1Message.textContent, 'Please fill in this field.', 'Required error message for text input');
   setValue(block, '#f1', 'abc');
-  assert.equal(f1.querySelector('.field-invalid .field-description'), undefined, 'Not Required error message for number input');
+  assert.equal(f1.querySelector('.field-invalid .field-description'), undefined, 'Not Required error message for text input');
 
   // number input error message
   const f2 = block.querySelector('#f2').parentElement;


### PR DESCRIPTION
Context:

  The OOTB browser messages cannot be localised as they are not part of our code and these messages often vary from 
  browser to browser. 
  In this PR these browser validity messages are replaced by a set of fixed strings maintained in the _`constants.js`_ file , 
  so that OOTB error messages are consistent across browsers and localisable.
  
  cc: @vdua 

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://dev--aem-boilerplate-forms--adobe-rnd.hlx.page/
- After: https://errormessage--aem-boilerplate-forms--adobe-rnd.hlx.page/

