### PR TITLE
feat: allow custom component to have its own model definition

### DIFF
--- a/scripts/form-editor-support.js
+++ b/scripts/form-editor-support.js
@@ -62,6 +62,13 @@ function annotateFormFragment(fragmentFieldWrapper, fragmentDefinition) {
   }
 }
 
+function getPropertyModel(fd) {
+  if (!fd[':type'] || fd[':type'].startsWith('core/fd/components')) {
+    return fd.fieldType === 'image' || fd.fieldType === 'button' ? `form-${fd.fieldType}` : fd.fieldType;
+  }
+  return fd[':type'];
+}
+
 function annotateItems(items, formDefinition, formFieldMap) {
   for (let i = items.length - 1; i >= 0; i -= 1) {
     const fieldWrapper = items[i];
@@ -73,13 +80,13 @@ function annotateItems(items, formDefinition, formFieldMap) {
           fieldWrapper.setAttribute('data-aue-type', 'richtext');
           fieldWrapper.setAttribute('data-aue-behavior', 'component');
           fieldWrapper.setAttribute('data-aue-resource', `urn:aemconnection:${fd.properties['fd:path']}`);
-          fieldWrapper.setAttribute('data-aue-model', fd.fieldType);
+          fieldWrapper.setAttribute('data-aue-model', getPropertyModel(fd));
           fieldWrapper.setAttribute('data-aue-label', 'Text');
           fieldWrapper.setAttribute('data-aue-prop', 'value');
         } else if (!fd.properties['fd:fragment']) {
           fieldWrapper.setAttribute('data-aue-type', 'component');
           fieldWrapper.setAttribute('data-aue-resource', `urn:aemconnection:${fd.properties['fd:path']}`);
-          fieldWrapper.setAttribute('data-aue-model', fd.fieldType === 'image' || fd.fieldType === 'button' ? `form-${fd.fieldType}` : fd.fieldType);
+          fieldWrapper.setAttribute('data-aue-model', getPropertyModel(fd));
           fieldWrapper.setAttribute('data-aue-label', fd.label?.value || fd.name);
         }
       } else {

--- a/test/unit/form.authoring.test.js
+++ b/test/unit/form.authoring.test.js
@@ -49,6 +49,8 @@ describe('Universal Editor Authoring Test Cases', () => {
             assert.equal(textNodeCount, Object.keys(fd[':items']).length, `fragment items not set ${textNodeCount} ${fd.id}`);
           } else if (fd.fieldType === 'plain-text') {
             testPlainTextAnnotation(node, fd, 'richtext', fd.fieldType);
+          } else if (fd[':type'] === 'rating') {
+            testAnnotation(node, fd, 'component', fd[':type']);
           } else if (!fd.properties['fd:fragment']) {
             testAnnotation(node, fd, 'component', fd.fieldType);
           }

--- a/test/unit/forms/universaleditorform.js
+++ b/test/unit/forms/universaleditorform.js
@@ -13,6 +13,17 @@ export const ueFormDef = {
         'fd:path': '/content/test2/index/jcr:content/root/section_0/form/textinput',
       },
     },
+    rating: {
+      id: 'rating-input',
+      fieldType: 'text-input',
+      label: {
+        value: 'Text Input',
+      },
+      properties: {
+        'fd:path': '/content/test2/index/jcr:content/root/section_0/form/textinput',
+      },
+      ':type': 'rating',
+    },
     panelcontainer: {
       id: 'panelcontainer-084914a499',
       fieldType: 'panel',
@@ -39,6 +50,7 @@ export const ueFormDef = {
           properties: {
             'fd:path': '/content/test2/index/jcr:content/root/section_0/form/panelcontainer/textinput',
           },
+          ':type': 'core/fd/components/form/textinput/v1/textinput',
         },
       },
     },
@@ -65,11 +77,13 @@ export const ueFormDef = {
           properties: {
             'fd:path': '/content/test2/formfrag3/jcr:content/root/section/form/textinput',
           },
+          ':type': 'core/fd/components/form/textinput/v1/textinput',
         },
       },
       ':itemsOrder': [
         'textinput_360975137',
       ],
+      ':type': 'core/fd/components/form/panelcontainer/v1/panelcontainer',
     },
   },
   ':itemsOrder': ['textinput', 'panelcontainer', 'fragment_1198843043'],


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://ue-custompropsdef--aem-boilerplate-forms--adobe-rnd.hlx.live/
