### PR TITLE
feat: Custom function segregation for multiple form

### DIFF
--- a/blocks/form/constant.js
+++ b/blocks/form/constant.js
@@ -28,3 +28,8 @@ export function setSubmitBaseUrl(url) {
 export function getSubmitBaseUrl() {
   return submitBaseUrl;
 }
+
+export const formIdPathMapping = {
+  L2NvbnRlbnQvZm9ybXMvYWYvcmFlL2Yx: '../../../myforms/f1/functions.js',
+  L2NvbnRlbnQvZm9ybXMvYWYvcmFlL2Yy: '../../../myforms/f2/functions.js',
+};

--- a/blocks/form/functions.js
+++ b/blocks/form/functions.js
@@ -1,32 +1,5 @@
-/**
- * Get Full Name
- * @name getFullName Concats first name and last name
- * @param {string} firstname in Stringformat
- * @param {string} lastname in Stringformat
- * @return {string}
- */
-function getFullName(firstname, lastname) {
-  return `${firstname} ${lastname}`.trim();
+import { formIdPathMapping } from './constant.js';
+
+export default function decorate(id) {
+  return formIdPathMapping ? formIdPathMapping[id] : null;
 }
-
-/**
- * Calculate the number of days between two dates.
- * @param {*} endDate
- * @param {*} startDate
- * @returns {number} returns the number of days between two dates
- */
-function days(endDate, startDate) {
-  const start = typeof startDate === 'string' ? new Date(startDate) : startDate;
-  const end = typeof endDate === 'string' ? new Date(endDate) : endDate;
-
-  // return zero if dates are valid
-  if (Number.isNaN(start.getTime()) || Number.isNaN(end.getTime())) {
-    return 0;
-  }
-
-  const diffInMs = Math.abs(end.getTime() - start.getTime());
-  return Math.floor(diffInMs / (1000 * 60 * 60 * 24));
-}
-
-// eslint-disable-next-line import/prefer-default-export
-export { getFullName, days };

--- a/blocks/form/rules/RuleEngineWorker.js
+++ b/blocks/form/rules/RuleEngineWorker.js
@@ -56,7 +56,8 @@ onmessage = (e) => {
   }
 
   if (!customFunctionRegistered) {
-    registerCustomFunctions().then(() => {
+    const { id } = e.data.payload;
+    registerCustomFunctions(id).then(() => {
       customFunctionRegistered = true;
       handleMessageEvent(e);
     });

--- a/blocks/form/rules/functionRegistration.js
+++ b/blocks/form/rules/functionRegistration.js
@@ -18,8 +18,9 @@
  * the terms of the Adobe license agreement accompanying it.
  ************************************************************************ */
 import { registerFunctions } from './model/afb-runtime.js';
+import decorate from '../functions.js';
 
-export default async function registerCustomFunctions() {
+export default async function registerCustomFunctions(id) {
   try {
     // eslint-disable-next-line no-inner-declarations
     function registerFunctionsInRuntime(module) {
@@ -36,8 +37,11 @@ export default async function registerCustomFunctions() {
       }
     }
 
-    const customFunctionModule = await import('../functions.js');
+    // const customFunctionModule = await import('../functions.js');
     const ootbFunctionModule = await import('./functions.js');
+    const customFunctionPath = decorate(id);
+    const customFunctionModule = await import(`${customFunctionPath}`);
+
     registerFunctionsInRuntime(ootbFunctionModule);
     registerFunctionsInRuntime(customFunctionModule);
   } catch (e) {

--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -299,7 +299,7 @@ async function fetchData({ id }) {
 
 export async function initAdaptiveForm(formDef, createForm) {
   const data = await fetchData(formDef);
-  await registerCustomFunctions();
+  await registerCustomFunctions(formDef?.id);
   const form = await initializeRuleEngineWorker({
     ...formDef,
     data,

--- a/myforms/f1/functions.js
+++ b/myforms/f1/functions.js
@@ -1,0 +1,11 @@
+/**
+ * Get Country Name
+ * @name getFullName Fetches country name
+ * @return {string}
+ */
+function getCountryName() {
+  return 'India';
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export { getCountryName };

--- a/myforms/f2/functions.js
+++ b/myforms/f2/functions.js
@@ -1,0 +1,11 @@
+/**
+ * Get City Name
+ * @name getFullName Fetches city name
+ * @return {string}
+ */
+function getCityName() {
+  return 'Bangalore';
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export { getCityName };


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://customfunctionpoc--aem-boilerplate-forms--adobe-rnd.hlx.live/

There are two forms
https://customfunctionpoc--aem-boilerplate-forms--adobe-rnd.hlx.live/drafts/rae/f1
https://customfunctionpoc--aem-boilerplate-forms--adobe-rnd.hlx.live/drafts/rae/f2

It loads different custom function files.
