### PR TITLE
fix(ue): allow decorator components to repaint in case of UE editing

### DIFF
--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -9,7 +9,6 @@ import {
 } from './aem.js';
 import { decorateRichtext } from './editor-support-rte.js';
 import { decorateMain } from './scripts.js';
-import { } from './form-editor-support.js';
 
 async function applyChanges(event) {
   // redecorate default content and blocks on patches (in the properties rail)

--- a/scripts/form-editor-support.js
+++ b/scripts/form-editor-support.js
@@ -248,6 +248,9 @@ async function applyChanges(event) {
           } else {
             parent.replaceChildren();
           }
+          if (parent.hasAttribute('data-component-status')) {
+            parent.removeAttribute('data-component-status');
+          }
           await generateFormRendition(parentDef, parent, getItems);
           annotateItems(parent.childNodes, formDef, {});
           return true;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://ue-fixes--aem-boilerplate-forms--adobe-rnd.hlx.live/
