### PR TITLE
Enabling loading of form-editor-support for UE always

### DIFF
--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -102,6 +102,7 @@ function attachEventListners(main) {
     const applied = await applyChanges(event);
     if (!applied) window.location.reload();
   }));
+  import('./form-editor-support.js');
 }
 
 attachEventListners(document.querySelector('main'));


### PR DESCRIPTION
Extra config in AEM is not required for forms with this change to support UE

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://vdua-patch-1--aem-boilerplate-forms--adobe-rnd.hlx.live/
