### PR TITLE
fix(ue): empty panel label breaks UE patch event

### DIFF
--- a/scripts/form-editor-support.js
+++ b/scripts/form-editor-support.js
@@ -106,7 +106,7 @@ function annotateItems(items, formDefinition, formFieldMap) {
   try {
     for (let i = items.length - 1; i >= 0; i -= 1) {
       const fieldWrapper = items[i];
-      if (fieldWrapper.classList.contains('field-wrapper')) {
+      if (fieldWrapper.classList?.contains('field-wrapper')) {
         const { id } = fieldWrapper.dataset;
         const fd = getFieldById(formDefinition, id, formFieldMap);
         if (fd && fd.properties) {
@@ -279,7 +279,7 @@ export async function applyChanges(event) {
           }
           const parent = element.closest('.panel-wrapper') || element.closest('form') || element.querySelector('form');
           const parentDef = getFieldById(formDef, parent.dataset.id, {});
-          if (parent.classList.contains('panel-wrapper')) {
+          if (parent.classList?.contains('panel-wrapper') && parent.querySelector('legend')) {
             const panelLabel = parent.querySelector('legend');
             parent.replaceChildren(panelLabel);
           } else {

--- a/test/e2e/main/page/universalEditorBasePage.js
+++ b/test/e2e/main/page/universalEditorBasePage.js
@@ -20,7 +20,7 @@ export class UniversalEditorBase {
     iFrame: 'iframe[name="Main Content"]',
     panelHeaders: 'div[class="PanelHeader"]',
     propertyPagePath: 'button[aria-label="Properties"]',
-    componentTitleInProperties: 'input[aria-label="Title"]',
+    componentTitleInProperties: 'textarea[aria-label="Title"]',
     deleteButton: 'button[aria-label="Delete"]',
     deleteConfirmationButton: '[data-variant="negative"][class*="aaz5ma_spectrum-ButtonGroup-Button"]',
     deletePopup: 'section[class*="spectrum-Dialog--destructive"]',

--- a/test/unit/fixtures/ue/events/event-patch-empty-title.js
+++ b/test/unit/fixtures/ue/events/event-patch-empty-title.js
@@ -1,0 +1,36 @@
+// eslint-disable-next-line import/prefer-default-export
+export const uePatchEmptyTitleEvent = {
+  request: {
+    connections: [
+      {
+        name: 'aemconnection',
+        protocol: 'xwalk',
+        uri: 'https://author-p10652-e203356-cmstg.adobeaemcloud.com',
+      },
+    ],
+    target: {
+      resource: 'urn:aemconnection:/content/ng-test1/index/jcr:content/root/section_0/form/panelcontainer_968965795/textinput',
+      type: 'component',
+      prop: '',
+    },
+    patch: [
+      {
+        op: 'replace',
+        path: '/jcr:title',
+        value: 'Text Input new',
+      },
+    ],
+  },
+  response: {
+    updates: [
+      {
+        resource: 'urn:aemconnection:/content/ng-test1/index/jcr:content/root/section_0/form',
+        content: '\n<div class="form" data-aue-type="container" data-aue-behavior="component" data-aue-model="form" data-aue-label="Adaptive Form" data-aue-filter="form" data-aue-resource="urn:aemconnection:/content/ng-test1/index/jcr:content/root/section_0/form">\n    <div>\n        <div>\n            <pre>\n                <code>"{\\"id\\":\\"L2NvbnRlbnQvbmctdGVzdDEvaW5kZXgvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==\\",\\"fieldType\\":\\"form\\",\\"lang\\":\\"en-US\\",\\"action\\":\\"\\/adobe\\/forms\\/af\\/submit\\/L2NvbnRlbnQvbmctdGVzdDEvaW5kZXgvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==\\",\\"properties\\":{\\"fd:path\\":\\"\\/content\\/ng-test1\\/index\\/jcr:content\\/root\\/section_0\\/form\\",\\"fd:schemaType\\":\\"BASIC\\",\\"fd:roleAttribute\\":null,\\"fd:formDataEnabled\\":false},\\"events\\":{\\"custom:setProperty\\":[\\"$event.payload\\"]},\\":itemsOrder\\":[\\"panelcontainer_968965795\\"],\\"metadata\\":{\\"version\\":\\"1.0.0\\",\\"grammar\\":\\"json-formula-1.0.0\\"},\\"adaptiveform\\":\\"0.14.0\\",\\":type\\":\\"fd\\/franklin\\/components\\/form\\/v1\\/form\\",\\":items\\":{\\"panelcontainer_968965795\\":{\\"id\\":\\"panelcontainer-5012648f84\\",\\"fieldType\\":\\"panel\\",\\"name\\":\\"panelcontainer_9689657951723632917367\\",\\"visible\\":true,\\"enabled\\":true,\\"label\\":{\\"value\\":\\"\\"},\\"events\\":{\\"custom:setProperty\\":[\\"$event.payload\\"]},\\"properties\\":{\\"fd:dor\\":{\\"dorExclusion\\":false,\\"dorExcludeTitle\\":false,\\"dorExcludeDescription\\":false},\\"fd:path\\":\\"\\/content\\/ng-test1\\/index\\/jcr:content\\/root\\/section_0\\/form\\/panelcontainer_968965795\\"},\\":itemsOrder\\":[\\"textinput\\"],\\":type\\":\\"core\\/fd\\/components\\/form\\/panelcontainer\\/v1\\/panelcontainer\\",\\":items\\":{\\"textinput\\":{\\"id\\":\\"textinput-3eb2e7d0b6\\",\\"fieldType\\":\\"text-input\\",\\"name\\":\\"textinput1723788365526\\",\\"visible\\":true,\\"type\\":\\"string\\",\\"enabled\\":true,\\"label\\":{\\"value\\":\\"Text Input new\\"},\\"events\\":{\\"custom:setProperty\\":[\\"$event.payload\\"]},\\"properties\\":{\\"fd:dor\\":{\\"dorExclusion\\":false},\\"fd:path\\":\\"\\/content\\/ng-test1\\/index\\/jcr:content\\/root\\/section_0\\/form\\/panelcontainer_968965795\\/textinput\\"},\\":type\\":\\"core\\/fd\\/components\\/form\\/textinput\\/v1\\/textinput\\"}}}}}"</code>\n            </pre>\n        </div>\n    </div>\n</div>\n',
+      },
+    ],
+  },
+  patch: {
+    name: 'jcr:title',
+    value: 'Text Input new',
+  },
+};

--- a/test/unit/fixtures/ue/events/formdefinition-patch-empty-title.js
+++ b/test/unit/fixtures/ue/events/formdefinition-patch-empty-title.js
@@ -1,0 +1,55 @@
+// eslint-disable-next-line import/prefer-default-export
+export const ueFormDefForPatchEmptyTitleTest = {
+  id: 'L2NvbnRlbnQvbmctdGVzdDEvaW5kZXgvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==',
+  fieldType: 'form',
+  lang: 'en',
+  action: '/adobe/forms/af/submit/L2NvbnRlbnQvbmctdGVzdDEvaW5kZXgvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==',
+  properties: {
+    'fd:path': '/content/ng-test1/index/jcr:content/root/section_0/form',
+  },
+  ':itemsOrder': [
+    'panelcontainer_968965795',
+  ],
+  metadata: {
+    version: '1.0.0',
+    grammar: 'json-formula-1.0.0',
+  },
+  adaptiveform: '0.14.0',
+  ':type': 'fd/franklin/components/form/v1/form',
+  ':items': {
+    panelcontainer_968965795: {
+      id: 'panelcontainer-5012648f84',
+      fieldType: 'panel',
+      name: 'panelcontainer_9689657951723632917367',
+      visible: true,
+      enabled: true,
+      label: {
+        value: '',
+      },
+      properties: {
+        'fd:path': '/content/ng-test1/index/jcr:content/root/section_0/form/panelcontainer_968965795',
+      },
+      ':itemsOrder': [
+        'textinput',
+      ],
+      ':type': 'core/fd/components/form/panelcontainer/v1/panelcontainer',
+      ':items': {
+        textinput: {
+          id: 'textinput-3eb2e7d0b6',
+          fieldType: 'text-input',
+          name: 'textinput1723788365526',
+          visible: true,
+          type: 'string',
+          enabled: true,
+          label: {
+            value: 'Text Input',
+          },
+          properties: {
+            'fd:path': '/content/ng-test1/index/jcr:content/root/section_0/form/panelcontainer_968965795/textinput',
+          },
+          ':type': 'core/fd/components/form/textinput/v1/textinput',
+        },
+      },
+    },
+  },
+};

--- a/test/unit/form.authoring.test.js
+++ b/test/unit/form.authoring.test.js
@@ -11,9 +11,11 @@ import { ueAddEvent } from './fixtures/ue/events/event-add.js';
 import { ueAddEventForWizardNavigation } from './fixtures/ue/events/event-add-wizardnavigation.js';
 import { uePatchEvent } from './fixtures/ue/events/event-patch.js';
 import { uePatchTitleEvent } from './fixtures/ue/events/event-patch-title.js';
+import { uePatchEmptyTitleEvent } from './fixtures/ue/events/event-patch-empty-title.js';
 import { ueFormDefForAddTest } from './fixtures/ue/events/formdefinition-add.js';
 import { ueFormDefForPatchTest } from './fixtures/ue/events/formdefinition-patch.js';
 import { ueFormDefForPatchTitleTest } from './fixtures/ue/events/formdefinition-patch-title.js';
+import { ueFormDefForPatchEmptyTitleTest } from './fixtures/ue/events/formdefinition-patch-empty-title.js';
 import { ueFormDefForWizardNavigationTest } from './fixtures/ue/events/formdefinition-wizardnavigation.js';
 import { renderForm } from './testUtils.js';
 
@@ -175,6 +177,23 @@ describe('Universal Editor Authoring Test Cases', () => {
     assert.equal(panel.childNodes.length, 2);
     const labelEl = panel.querySelector('legend[for="panelcontainer-5012648f84"]');
     assert.equal(labelEl.textContent, 'Panel');
+    const textInputElLabel = panel.querySelector('label[for="textinput-3eb2e7d0b6"]');
+    assert.equal(textInputElLabel.textContent, 'Text Input new');
+    document.body.replaceChildren();
+  });
+
+  it('test UE patch event for panel empty title', async () => {
+    await renderForm(ueFormDefForPatchEmptyTitleTest);
+    window.hlx.codeBasePath = '../../';
+    const applied = await applyChanges({ detail: uePatchEmptyTitleEvent });
+    assert.equal(applied, true);
+    const formEl = document.querySelector('form');
+    assert.equal(formEl.childNodes.length, 1); // only 1 panel is there
+    const panel = formEl.querySelector('.panel-wrapper');
+    // only 1 text-input (no panel legend)
+    assert.equal(panel.childNodes.length, 1);
+    const labelEl = panel.querySelector('legend[for="panelcontainer-5012648f84"]');
+    assert.equal(labelEl == null, true);
     const textInputElLabel = panel.querySelector('label[for="textinput-3eb2e7d0b6"]');
     assert.equal(textInputElLabel.textContent, 'Text Input new');
     document.body.replaceChildren();


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://ue--aem-boilerplate-forms--adobe-rnd.hlx.live/
