### PR TITLE
fix(ue): switching back to edit mode does not annotates the form

### DIFF
--- a/scripts/form-editor-support.js
+++ b/scripts/form-editor-support.js
@@ -341,9 +341,8 @@ function attachEventListners(main) {
 
   if (document.documentElement.classList.contains('adobe-ue-edit')) {
     ueEditModeHandler();
-  } else {
-    document.body.addEventListener('aue:ui-edit', ueEditModeHandler);
   }
+  document.body.addEventListener('aue:ui-edit', ueEditModeHandler);
 }
 const observer = new MutationObserver(instrumentForms);
 observer.observe(document, { childList: true, subtree: true, attributeFilter: ['form'] });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://ue--aem-boilerplate-forms--adobe-rnd.hlx.live/
