### PR TITLE
[DRAFT] Hlx5

### DIFF
--- a/fstab.yaml
+++ b/fstab.yaml
@@ -1,5 +1,0 @@
-mountpoints:
-  /:
-    url: https://author-p133911-e1313554.adobeaemcloud.com/bin/franklin.delivery/jalagari/demo/main
-    type: "markup"
-    suffix: ".html"

--- a/test/e2e/global-setup.js
+++ b/test/e2e/global-setup.js
@@ -2,10 +2,8 @@ import { chromium, expect } from '@playwright/test';
 
 const filePath = './LoginAuth.json';
 const baseUrl = 'https://author-p133911-e1313554.adobeaemcloud.com/aem/start.html';
-// const emailId = process.env.AEM_userName;
-// const password = process.env.AEM_password;
-const emailId = 'ptippa.test@outlook.com';
-const password = 'bqD_BsY2+m)32pV';
+const emailId = process.env.AEM_userName;
+const password = process.env.AEM_password;
 
 const selectors = {
   iFrame: 'iframe[id*="exc-app-sandbox"]',

--- a/test/e2e/global-setup.js
+++ b/test/e2e/global-setup.js
@@ -2,8 +2,10 @@ import { chromium, expect } from '@playwright/test';
 
 const filePath = './LoginAuth.json';
 const baseUrl = 'https://author-p133911-e1313554.adobeaemcloud.com/aem/start.html';
-const emailId = process.env.AEM_userName;
-const password = process.env.AEM_password;
+// const emailId = process.env.AEM_userName;
+// const password = process.env.AEM_password;
+const emailId = 'ptippa.test@outlook.com';
+const password = 'bqD_BsY2+m)32pV';
 
 const selectors = {
   iFrame: 'iframe[id*="exc-app-sandbox"]',

--- a/test/e2e/utils.js
+++ b/test/e2e/utils.js
@@ -47,4 +47,8 @@ const openPage = async (page, relativeURL) => {
   await page.goto(url, { waitUntil: 'networkidle' });
 };
 
-export { openPage, getCurrentBranch };
+const openForm = async (page, formURL) => {
+  await page.goto(formURL, { waitUntil: 'networkidle' });
+};
+
+export { openPage, openForm, getCurrentBranch };

--- a/test/e2e/x-walk/Doc-based/submissionValidation.spec.js
+++ b/test/e2e/x-walk/Doc-based/submissionValidation.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures.js';
-import { fillField, openPage } from '../../utils.js';
+import { fillField, openPage, openForm } from '../../utils.js';
 
 const inputValues = {
   textInput: 'adobe',
@@ -26,18 +26,19 @@ const titles = ['Text Input', 'Check Box Group', 'Number Input', 'Radio Button',
 // eslint-disable-next-line no-unused-vars
 let requestPayload = null;
 
-test.describe.skip('Form Rendering and Submission Validation', async () => {
-  const testURL = '/drafts/tests/doc-based/submissionvalidation';
+test.describe('Form Rendering and Submission Validation', async () => {
+  const testURL = 'https://main--aem-boilerplate-forms-doc-based--adobe-rnd.aem.page/submissionvalidation';
 
   test('Validate Doc-Based Form components and submission payload @chromium-only', async ({ page }) => {
-    await openPage(page, testURL);
+    // await openPage(page, testURL);
+    await openForm(page, testURL);
     await expect(page.getByLabel('Text Input')).toBeVisible();
 
     // listeners to fetch payload form submission.
     page.on('request', async (request) => {
-      if (request.url().includes(testURL)) {
-        requestPayload = request.postData();
-      }
+      // if (request.url().includes(testURL)) {
+      requestPayload = request.postData();
+      // }
     });
 
     // eslint-disable-next-line no-restricted-syntax

--- a/test/e2e/x-walk/Doc-based/submissionValidation.spec.js
+++ b/test/e2e/x-walk/Doc-based/submissionValidation.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures.js';
-import { fillField, openPage, openForm } from '../../utils.js';
+import { fillField, openForm } from '../../utils.js';
 
 const inputValues = {
   textInput: 'adobe',
@@ -30,15 +30,12 @@ test.describe('Form Rendering and Submission Validation', async () => {
   const testURL = 'https://main--aem-boilerplate-forms-doc-based--adobe-rnd.aem.page/submissionvalidation';
 
   test('Validate Doc-Based Form components and submission payload @chromium-only', async ({ page }) => {
-    // await openPage(page, testURL);
     await openForm(page, testURL);
     await expect(page.getByLabel('Text Input')).toBeVisible();
 
     // listeners to fetch payload form submission.
     page.on('request', async (request) => {
-      // if (request.url().includes(testURL)) {
       requestPayload = request.postData();
-      // }
     });
 
     // eslint-disable-next-line no-restricted-syntax

--- a/test/e2e/x-walk/UE-sites/ratingComponentValidationRunTIme.spec.js
+++ b/test/e2e/x-walk/UE-sites/ratingComponentValidationRunTIme.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures.js';
-import { openPage, openForm } from '../../utils.js';
+import { openForm } from '../../utils.js';
 
 const emoji = ['😢', '😊'];
 let rating = null;
@@ -11,27 +11,23 @@ const selector = {
   emoji: '.rating.hover span.emoji',
 };
 
-const partialUrl = '/L2NvbnRlbnQvcmF0aW5nQ29tcG9uZW50VGVzdENvbGxhdGVyYWwvaW5kZXgvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==';
 const starsSelected = 'star hover selected';
 
 test.describe('custom component validation', () => {
   // const testURL = '/drafts/tests/x-walk/ratingvalidation';
-  const testURL = 'https://main--aem-boilerplate-aem--ujjwal5.aem.live/content/test-site-ujj/';
+  const testURL = 'https://main--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/rating-component';
 
   test('rating custom component validation @chromium-only', async ({ page }) => {
-    // await openPage(page, testURL);
     await openForm(page, testURL);
 
     await page.evaluate(async () => {
       // eslint-disable-next-line no-undef,no-underscore-dangle
-      myForm._jsonModel.action = 'https://main--aem-boilerplate-aem--ujjwal5.aem.live/adobe/forms/af/submit/L2NvbnRlbnQvdGVzdC1zaXRlLXVqai9pbmRleC9qY3I6Y29udGVudC9yb290L3NlY3Rpb25fMC9mb3Jt';
+      myForm._jsonModel.action = 'https://main--aem-boilerplate-forms--adobe-rnd.aem.live/adobe/forms/af/submit/L2NvbnRlbnQvYWVtLWJvaWxlcnBsYXRlLWZvcm1zLXh3YWxrLWNvbGxhdGVyYWxzL3JhdGluZy1jb21wb25lbnQvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==';
     });
 
     // listeners to fetch payload form submission.
     page.on('request', async (request) => {
-      // if (request.url().includes(partialUrl)) {
       requestPayload = request.postData();
-      // }
     });
 
     const ratingLocator = page.locator(selector.ratingComponent);

--- a/test/e2e/x-walk/UE-sites/ratingComponentValidationRunTIme.spec.js
+++ b/test/e2e/x-walk/UE-sites/ratingComponentValidationRunTIme.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures.js';
-import { openPage } from '../../utils.js';
+import { openPage, openForm } from '../../utils.js';
 
 const emoji = ['😢', '😊'];
 let rating = null;
@@ -14,22 +14,24 @@ const selector = {
 const partialUrl = '/L2NvbnRlbnQvcmF0aW5nQ29tcG9uZW50VGVzdENvbGxhdGVyYWwvaW5kZXgvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==';
 const starsSelected = 'star hover selected';
 
-test.describe.skip('custom component validation', () => {
-  const testURL = '/drafts/tests/x-walk/ratingvalidation';
+test.describe('custom component validation', () => {
+  // const testURL = '/drafts/tests/x-walk/ratingvalidation';
+  const testURL = 'https://main--aem-boilerplate-aem--ujjwal5.aem.live/content/test-site-ujj/';
 
   test('rating custom component validation @chromium-only', async ({ page }) => {
-    await openPage(page, testURL);
+    // await openPage(page, testURL);
+    await openForm(page, testURL);
 
     await page.evaluate(async () => {
       // eslint-disable-next-line no-undef,no-underscore-dangle
-      myForm._jsonModel.action = 'https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/adobe/forms/af/submit/L2NvbnRlbnQvcmF0aW5nQ29tcG9uZW50VGVzdENvbGxhdGVyYWwvaW5kZXgvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==';
+      myForm._jsonModel.action = 'https://main--aem-boilerplate-aem--ujjwal5.aem.live/adobe/forms/af/submit/L2NvbnRlbnQvdGVzdC1zaXRlLXVqai9pbmRleC9qY3I6Y29udGVudC9yb290L3NlY3Rpb25fMC9mb3Jt';
     });
 
     // listeners to fetch payload form submission.
     page.on('request', async (request) => {
-      if (request.url().includes(partialUrl)) {
-        requestPayload = request.postData();
-      }
+      // if (request.url().includes(partialUrl)) {
+      requestPayload = request.postData();
+      // }
     });
 
     const ratingLocator = page.locator(selector.ratingComponent);


### PR DESCRIPTION
Single repo: https://github.com/adobe-rnd/aem-boilerplate-forms

Site 1: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/rating-component
Site 2: https://main--aem-boilerplate-forms-doc-based--adobe-rnd.aem.page/submissionvalidation

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

@pranay-tippa Please use this PR as reference to migrate all CC test collaterals to UE.
And helix4 based tests to helix5.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/
- After: https://hlx5--aem-boilerplate-forms--adobe-rnd.aem.live/
