### PR TITLE
fix: modal not opening when closed using escape button

### DIFF
--- a/blocks/form/components/modal/modal.js
+++ b/blocks/form/components/modal/modal.js
@@ -29,12 +29,12 @@ export class Modal {
     });
     dialog.querySelector('.close-button').addEventListener('click', () => {
       dialog.close();
-      if (this.formModel) {
-        this.formModel.getElement(panel?.id).visible = false;
-      }
     });
     dialog.addEventListener('close', () => {
       document.body.classList.remove('modal-open');
+      if (this.formModel) {
+        this.formModel.getElement(panel?.id).visible = false;
+      }
     });
     return dialog;
   }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://modal-fix--aem-boilerplate-forms--adobe-rnd.hlx.live/
