### PR TITLE
feat: adding dataRef fields to Image and Plain-Text components

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -2058,6 +2058,12 @@
         "label": "Alternate text"
       },
       {
+        "component": "text",
+        "name": "dataRef",
+        "label": "Bind reference",
+        "valueType": "string"
+      },
+      {
         "component": "boolean",
         "name": "visible",
         "label": "Show Component",
@@ -3777,6 +3783,12 @@
         "label": "Name",
         "valueType": "string",
         "required": true
+      },
+      {
+        "component": "text",
+        "name": "dataRef",
+        "label": "Bind reference",
+        "valueType": "string"
       },
       {
         "component": "boolean",

--- a/models/form-components/_image.json
+++ b/models/form-components/_image.json
@@ -48,6 +48,12 @@
                     "label": "Alternate text"
                 },
                 {
+                    "component": "text",
+                    "name": "dataRef",
+                    "label": "Bind reference",
+                    "valueType": "string"
+                },
+                {
                     "component": "boolean",
                     "name": "visible",
                     "label": "Show Component",

--- a/models/form-components/_text.json
+++ b/models/form-components/_text.json
@@ -30,6 +30,12 @@
           "required": true
         },
         {
+          "component": "text",
+          "name": "dataRef",
+          "label": "Bind reference",
+          "valueType": "string"
+        },
+        {
           "component": "boolean",
           "name": "visible",
           "label": "Show Component",


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://forms-18434--aem-boilerplate-forms--adobe-rnd.aem.page/