### PR TITLE
fix: prevent scroll into view when user clicks on a field

### DIFF
--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -49,7 +49,8 @@ function handleActiveChild(id, form) {
   if (field) {
     field.closest('.field-wrapper').dataset.active = true;
     field.focus();
-    if (document.activeElement !== field) {
+    // prevent scroll into view when user clicks on a field.
+    if (document.activeElement !== field && !field.contains(document.activeElement)) {
       field.scrollIntoView({ behavior: 'smooth' });
     }
   }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  // globalSetup: './test/e2e/global-setup.js',
+  globalSetup: './test/e2e/global-setup.js',
   testDir: './test/e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
 export default defineConfig({
-  globalSetup: './test/e2e/global-setup.js',
+  // globalSetup: './test/e2e/global-setup.js',
   testDir: './test/e2e',
   /* Run tests in files in parallel */
   fullyParallel: true,

--- a/test/README.md
+++ b/test/README.md
@@ -44,3 +44,5 @@ To debug a specific test file, use the following command
 ```sh
 npm run debug:e2e <name-of-the-test-file>
 ```
+
+**NOTE**: _To debug your e2e test locally comment the ``globalSetup`` in the ``playwright.config.js``_

--- a/test/e2e/x-walk/setFocus.spec.js
+++ b/test/e2e/x-walk/setFocus.spec.js
@@ -1,9 +1,9 @@
 import { test, expect } from '../fixtures.js';
 import { openPage } from '../utils.js';
 
-test.describe.skip('wizard tests', () => {
+test.describe('setFocus tests', () => {
   const testURL = '/drafts/tests/x-walk/wizardvalidation';
-  test('setFocus test', async ({ page }) => {
+  test.skip('setFocus test wizard', async ({ page }) => {
     await openPage(page, testURL);
     await expect(await page.$eval('fieldset[name="item_1"]', (el) => el.classList.contains('current-wizard-step'))).toBeTruthy(); // check first panel is active
     await expect(await page.$eval('li[data-index="0"]', (el) => el.classList.contains('wizard-menu-active-item'))).toBeTruthy(); // check first menu item is active
@@ -23,5 +23,15 @@ test.describe.skip('wizard tests', () => {
     await expect(await page.$eval('fieldset[name="item_3"]', (el) => el.classList.contains('current-wizard-step'))).toBeTruthy(); // check third panel is active
     await expect(await page.$eval('li[data-index="2"]', (el) => el.classList.contains('wizard-menu-active-item'))).toBeTruthy(); // check third menu item is active
     await expect(await page.locator('div').filter({ hasText: /^Email Input$/ })).toHaveAttribute('data-active', 'true'); // check email input is active
+  });
+
+  const url = '/content/aem-boilerplate-forms-xwalk-collaterals/set-focus';
+  test('scroll into view for set focus', async ({ page }) => {
+    await openPage(page, url);
+    const button = await page.getByRole('button', { name: 'Button' });
+    await button.click();
+    const textInput = await page.getByLabel('Text Input');
+    await expect(textInput).toBeFocused();
+    await expect(textInput).toBeInViewport();
   });
 });


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.page/content/aem-boilerplate-forms-xwalk-collaterals/set-focus
- After: https://scroll--aem-boilerplate-forms--adobe-rnd.aem.page/content/aem-boilerplate-forms-xwalk-collaterals/set-focus
