### PR TITLE
fix error messages not displaying via validate form rule

### DIFF
--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -78,13 +78,9 @@ async function fieldChanged(payload, form, generateFormRendition) {
         }
         break;
       case 'validationMessage':
-        {
-          const { validity } = payload.field;
-          if (field.setCustomValidity
-          && (validity?.expressionMismatch || validity?.customConstraint)) {
-            field.setCustomValidity(currentValue);
-            updateOrCreateInvalidMsg(field, currentValue);
-          }
+        if (field.setCustomValidity) {
+          field.setCustomValidity(currentValue);
+          updateOrCreateInvalidMsg(field, currentValue);
         }
         break;
       case 'value':

--- a/test/e2e/x-walk/errormessages.spec.js
+++ b/test/e2e/x-walk/errormessages.spec.js
@@ -4,10 +4,7 @@ import { openPage } from '../utils.js';
 test.describe('error messages test', () => {
   const testURL = '/content/aem-boilerplate-forms-xwalk-collaterals/error-messages';
 
-  test('required OOTB error message ', async ({ page }) => {
-    await openPage(page, testURL);
-    const submitButton = await page.getByRole('button', { name: 'Submit' });
-    await submitButton.click();
+  const validateErrorMessages = async (page) => {
     const f1 = await page.locator('input[name="f1"]').locator('..');
     expect(await f1.locator('.field-description').innerText()).toBe('Please fill in this field.');
     const f2 = await page.locator('input[name="f2"]').locator('..');
@@ -20,6 +17,20 @@ test.describe('error messages test', () => {
     expect(await f5.locator('.field-description').innerText()).toBe('Please fill in this field.');
     const f6 = await page.locator('input[name="f6"]').locator('..');
     expect(await f6.locator('.field-description').innerText()).toBe('Please fill in this field.');
+  }
+
+  test('required OOTB error message ', async ({ page }) => {
+    await openPage(page, testURL);
+    const submitButton = await page.getByRole('button', { name: 'Submit' });
+    await submitButton.click();
+    await validateErrorMessages(page);
+  });
+
+  test('validate form displays error messages ', async ({ page }) => {
+    await openPage(page, testURL);
+    const validateBtn = await page.getByRole('button', { name: 'Validate Form' });
+    await validateBtn.click();
+    await validateErrorMessages(page);
   });
 
   test('custom required error message', async ({ page }) => {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/error-messages
- After: https://validate--aem-boilerplate-forms--adobe-rnd.aem.live/content/aem-boilerplate-forms-xwalk-collaterals/error-messages
