### PR TITLE
UE Fix: Fixed Vanishing add and delete buttons when panel child properties are changed

### DIFF
--- a/blocks/form/components/repeat/repeat.js
+++ b/blocks/form/components/repeat/repeat.js
@@ -39,7 +39,7 @@ function createButton(label, icon) {
 }
 
 export function insertRemoveButton(fieldset, wrapper, form) {
-  const label = fieldset.dataset?.repeatDeleteButtonLabel || 'Remove';
+  const label = fieldset.dataset?.repeatDeleteButtonLabel || 'Delete';
   const removeButton = createButton(label, 'remove');
   removeButton.addEventListener('click', () => {
     fieldset.remove();

--- a/blocks/form/components/repeat/repeat.js
+++ b/blocks/form/components/repeat/repeat.js
@@ -109,8 +109,8 @@ export default function transferRepeatableDOM(form) {
     wrapper.dataset.repeatDeleteButtonLabel = el.dataset?.repeatDeleteButtonLabel ? el.dataset.repeatDeleteButtonLabel : 'Remove';
     el.insertAdjacentElement('beforebegin', wrapper);
     wrapper.append(...instances);
-    wrapper.querySelector('.item-remove')?.remove();
-    wrapper.querySelector('.repeat-actions')?.remove();
+    wrapper.querySelectorAll('.item-remove').forEach(element => element.remove());
+    wrapper.querySelectorAll('.repeat-actions').forEach(element => element.remove());
     const cloneNode = el.cloneNode(true);
     cloneNode.removeAttribute('id');
     wrapper['#repeat-template'] = cloneNode;

--- a/blocks/form/components/repeat/repeat.js
+++ b/blocks/form/components/repeat/repeat.js
@@ -104,7 +104,7 @@ export default function transferRepeatableDOM(form) {
     const wrapper = document.createElement('div');
     wrapper.dataset.min = el.dataset.min || 0;
     wrapper.dataset.max = el.dataset.max;
-    wrapper.dataset.variant = el.dataset.variant || 'addRemoveButtons';
+    wrapper.dataset.variant = el.dataset.variant || 'addDeleteButtons';
     wrapper.dataset.repeatAddButtonLabel = el.dataset?.repeatAddButtonLabel ? el.dataset.repeatAddButtonLabel : 'Add';
     wrapper.dataset.repeatDeleteButtonLabel = el.dataset?.repeatDeleteButtonLabel ? el.dataset.repeatDeleteButtonLabel : 'Remove';
     el.insertAdjacentElement('beforebegin', wrapper);

--- a/blocks/form/components/repeat/repeat.js
+++ b/blocks/form/components/repeat/repeat.js
@@ -109,8 +109,8 @@ export default function transferRepeatableDOM(form) {
     wrapper.dataset.repeatDeleteButtonLabel = el.dataset?.repeatDeleteButtonLabel ? el.dataset.repeatDeleteButtonLabel : 'Remove';
     el.insertAdjacentElement('beforebegin', wrapper);
     wrapper.append(...instances);
-    wrapper.querySelectorAll('.item-remove').forEach(element => element.remove());
-    wrapper.querySelectorAll('.repeat-actions').forEach(element => element.remove());
+    wrapper.querySelectorAll('.item-remove').forEach((element) => element.remove());
+    wrapper.querySelectorAll('.repeat-actions').forEach((element) => element.remove());
     const cloneNode = el.cloneNode(true);
     cloneNode.removeAttribute('id');
     wrapper['#repeat-template'] = cloneNode;

--- a/blocks/form/form.css
+++ b/blocks/form/form.css
@@ -338,8 +338,8 @@ main .form form .item-remove {
     order: 1;
 }
 
-main .form form div[data-variant="addRemoveButtons"] .item-add,
-main .form form div[data-variant="addRemoveButtons"] .item-remove {
+main .form form div[data-variant="addDeleteButtons"] .item-add,
+main .form form div[data-variant="addDeleteButtons"] .item-remove {
     display: block;
 }
 
@@ -639,7 +639,7 @@ main .form form .checkbox-group-wrapper.horizontal .field-description {
     :root {
         --form-field-horz-gap: 10px;
     }
-    
+
     main .form form .wizard  {
         .wizard-menu-items {
             gap: 20px;

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -399,12 +399,15 @@ export async function generateFormRendition(panel, container, getItems = (p) => 
 }
 
 function decoratePanelContainer(container, panel) {
+  if(!container || !panel) return;
   if (container.classList?.contains('panel-wrapper')) {
     if (panel.label && !container.querySelector(`legend[for=${container.dataset.id}]`)) {
       const legend = createLegend(panel);
-      container.insertAdjacentElement('afterbegin', legend);
+      if(legend) {
+        container.insertAdjacentElement('afterbegin', legend);
+      }
     }
-    
+
     if (container.dataset?.repeatable === 'true') {
       if (!container.querySelector('.repeat-actions')) {
         insertAddButton(container, container);

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -348,6 +348,27 @@ function inputDecorator(field, element) {
   }
 }
 
+function decoratePanelContainer(container, panel) {
+  if (!container || !panel) return;
+  if (container.classList?.contains('panel-wrapper')) {
+    if (panel.label && !container.querySelector(`legend[for=${container.dataset.id}]`)) {
+      const legend = createLegend(panel);
+      if (legend) {
+        container.insertAdjacentElement('afterbegin', legend);
+      }
+    }
+
+    if (container.dataset?.repeatable === 'true' && container.dataset?.variant !== 'noButtons') {
+      if (!container.querySelector(':scope > .repeat-actions')) {
+        insertAddButton(container, container);
+      }
+      if (!container.querySelector(':scope > .item-remove')) {
+        insertRemoveButton(container, container);
+      }
+    }
+  }
+}
+
 function renderField(fd) {
   const fieldType = fd?.fieldType?.replace('-input', '') ?? 'text';
   const renderer = fieldRenderers[fieldType];
@@ -396,27 +417,6 @@ export async function generateFormRendition(panel, container, getItems = (p) => 
   container.append(...children.filter((_) => _ != null));
   decoratePanelContainer(container, panel);
   await componentDecorator(container, panel);
-}
-
-function decoratePanelContainer(container, panel) {
-  if(!container || !panel) return;
-  if (container.classList?.contains('panel-wrapper')) {
-    if (panel.label && !container.querySelector(`legend[for=${container.dataset.id}]`)) {
-      const legend = createLegend(panel);
-      if(legend) {
-        container.insertAdjacentElement('afterbegin', legend);
-      }
-    }
-
-    if (container.dataset?.repeatable === 'true' && container.dataset?.variant !== 'noButtons') {
-      if (!container.querySelector(':scope > .repeat-actions')) {
-        insertAddButton(container, container);
-      }
-      if (!container.querySelector(':scope > .item-remove')) {
-        insertRemoveButton(container, container);
-      }
-    }
-  }
 }
 
 function enableValidation(form) {

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -409,10 +409,10 @@ function decoratePanelContainer(container, panel) {
     }
 
     if (container.dataset?.repeatable === 'true') {
-      if (!container.querySelector('.repeat-actions')) {
+      if (!container.querySelector(':scope > .repeat-actions')) {
         insertAddButton(container, container);
       }
-      if (!container.querySelector('.item-remove')) {
+      if (!container.querySelector(':scope > .item-remove')) {
         insertRemoveButton(container, container);
       }
     }

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -394,7 +394,26 @@ export async function generateFormRendition(panel, container, getItems = (p) => 
 
   const children = await Promise.all(promises);
   container.append(...children.filter((_) => _ != null));
+  decoratePanelContainer(container, panel);
   await componentDecorator(container, panel);
+}
+
+function decoratePanelContainer(container, panel) {
+  if (container.classList?.contains('panel-wrapper')) {
+    if (panel.label && !container.querySelector(`legend[for=${container.dataset.id}]`)) {
+      const legend = createLegend(panel);
+      container.insertAdjacentElement('afterbegin', legend);
+    }
+    
+    if (container.dataset?.repeatable === 'true') {
+      if (!container.querySelector('.repeat-actions')) {
+        insertAddButton(container, container);
+      }
+      if (!container.querySelector('.item-remove')) {
+        insertRemoveButton(container, container);
+      }
+    }
+  }
 }
 
 function enableValidation(form) {

--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -408,7 +408,7 @@ function decoratePanelContainer(container, panel) {
       }
     }
 
-    if (container.dataset?.repeatable === 'true') {
+    if (container.dataset?.repeatable === 'true' && container.dataset?.variant !== 'noButtons') {
       if (!container.querySelector(':scope > .repeat-actions')) {
         insertAddButton(container, container);
       }

--- a/blocks/form/models/form-components/_date-input.json
+++ b/blocks/form/models/form-components/_date-input.json
@@ -1,7 +1,7 @@
 {
     "definitions": [
         {
-            "title": "Date Picker",
+            "title": "Date Input",
             "id": "date-input",
             "plugins": {
                 "xwalk": {

--- a/blocks/form/models/form-components/_panel.json
+++ b/blocks/form/models/form-components/_panel.json
@@ -95,11 +95,11 @@
                                     "value": "noButtons"
                                 },
                                 {
-                                    "name": "Add & Remove Buttons",
-                                    "value": "addRemoveButtons"
+                                    "name": "Add & Delete Buttons",
+                                    "value": "addDeleteButtons"
                                 }
                             ],
-                            "value": "addRemoveButtons",
+                            "value": "addDeleteButtons",
                             "condition": { "===": [{"var" : "repeatable"}, true] }
                         },
                         {
@@ -115,7 +115,7 @@
                                             {
                                                 "var": "variant"
                                             },
-                                            "addRemoveButtons"
+                                            "addDeleteButtons"
                                         ]
                                     },
                                     {
@@ -142,7 +142,7 @@
                                             {
                                                 "var": "variant"
                                             },
-                                            "addRemoveButtons"
+                                            "addDeleteButtons"
                                         ]
                                     },
                                     {

--- a/component-definition.json
+++ b/component-definition.json
@@ -220,7 +220,7 @@
           }
         },
         {
-          "title": "Date Picker",
+          "title": "Date Input",
           "id": "date-input",
           "plugins": {
             "xwalk": {

--- a/component-models.json
+++ b/component-models.json
@@ -2799,11 +2799,11 @@
                 "value": "noButtons"
               },
               {
-                "name": "Add & Remove Buttons",
-                "value": "addRemoveButtons"
+                "name": "Add & Delete Buttons",
+                "value": "addDeleteButtons"
               }
             ],
-            "value": "addRemoveButtons",
+            "value": "addDeleteButtons",
             "condition": {
               "===": [
                 {
@@ -2826,7 +2826,7 @@
                     {
                       "var": "variant"
                     },
-                    "addRemoveButtons"
+                    "addDeleteButtons"
                   ]
                 },
                 {
@@ -2853,7 +2853,7 @@
                     {
                       "var": "variant"
                     },
-                    "addRemoveButtons"
+                    "addDeleteButtons"
                   ]
                 },
                 {

--- a/scripts/form-editor-support.js
+++ b/scripts/form-editor-support.js
@@ -307,7 +307,7 @@ export async function applyChanges(event) {
           const isRepeatable = parent.dataset.repeatable === 'true';
           if (isRepeatable) {
             const repeatActions = parent.querySelector('.repeat-actions');
-            const removeButton = parent.querySelector('.item-remove');            
+            const removeButton = parent.querySelector('.item-remove');
             if (repeatActions) elementsToKeep.push(repeatActions);
             if (removeButton) elementsToKeep.push(removeButton);
           }

--- a/scripts/form-editor-support.js
+++ b/scripts/form-editor-support.js
@@ -299,19 +299,7 @@ export async function applyChanges(event) {
           }
           const parent = element.closest('.panel-wrapper') || element.closest('form') || element.querySelector('form');
           const parentDef = getFieldById(formDef, parent.dataset.id, {});
-          const elementsToKeep = [];
-          if (parent.classList?.contains('panel-wrapper') && parent.querySelector(`legend[for=${parent.dataset.id}]`)) {
-            const panelLabel = parent.querySelector(`legend[for=${parent.dataset.id}]`);
-            elementsToKeep.push(panelLabel);
-          }
-          const isRepeatable = parent.dataset.repeatable === 'true';
-          if (isRepeatable) {
-            const repeatActions = parent.querySelector('.repeat-actions');
-            const removeButton = parent.querySelector('.item-remove');
-            if (repeatActions) elementsToKeep.push(repeatActions);
-            if (removeButton) elementsToKeep.push(removeButton);
-          }
-          parent.replaceChildren(...elementsToKeep);
+          parent.replaceChildren();
           if (parent.hasAttribute('data-component-status')) {
             parent.removeAttribute('data-component-status');
           }

--- a/scripts/form-editor-support.js
+++ b/scripts/form-editor-support.js
@@ -299,12 +299,19 @@ export async function applyChanges(event) {
           }
           const parent = element.closest('.panel-wrapper') || element.closest('form') || element.querySelector('form');
           const parentDef = getFieldById(formDef, parent.dataset.id, {});
+          const elementsToKeep = [];
           if (parent.classList?.contains('panel-wrapper') && parent.querySelector(`legend[for=${parent.dataset.id}]`)) {
             const panelLabel = parent.querySelector(`legend[for=${parent.dataset.id}]`);
-            parent.replaceChildren(panelLabel);
-          } else {
-            parent.replaceChildren();
+            elementsToKeep.push(panelLabel);
           }
+          const isRepeatable = parent.dataset.repeatable === 'true';
+          if (isRepeatable) {
+            const repeatActions = parent.querySelector('.repeat-actions');
+            const removeButton = parent.querySelector('.item-remove');            
+            if (repeatActions) elementsToKeep.push(repeatActions);
+            if (removeButton) elementsToKeep.push(removeButton);
+          }
+          parent.replaceChildren(...elementsToKeep);
           if (parent.hasAttribute('data-component-status')) {
             parent.removeAttribute('data-component-status');
           }

--- a/test/unit/fixtures/components/panel/doc-based-repeatable-min.html
+++ b/test/unit/fixtures/components/panel/doc-based-repeatable-min.html
@@ -1,5 +1,5 @@
 <form data-action="undefined" novalidate="" data-redirect-url="" data-thank-you-msg="" data-source="sheet" data-rules="false" data-id="undefined">
-  <div data-min="2" data-max="3" data-variant="addRemoveButtons" data-repeat-add-button-label="Add" data-repeat-delete-button-label="Remove" class="repeat-wrapper">
+  <div data-min="2" data-max="3" data-variant="addDeleteButtons" data-repeat-add-button-label="Add" data-repeat-delete-button-label="Remove" class="repeat-wrapper">
     <fieldset class="panel-wrapper field-doc-traveler field-wrapper" data-id="doc-traveler" id="doc-traveler" name="doc-traveler" data-max="3" data-min="2" data-repeatable="true" data-index="0">
       <legend for="doc-traveler" class="field-label">Traveler Info</legend>
       <div class="text-wrapper field-doc-name field-wrapper" data-fieldset="doc-traveler" data-id="doc-name" data-required-error-message="Please fill in this field." data-required="false"><label for="doc-name" class="field-label">Name</label><input type="text" id="doc-name" name="doc-name" autocomplete="off"></div>

--- a/test/unit/fixtures/components/panel/repeatable-panel-minItems.html
+++ b/test/unit/fixtures/components/panel/repeatable-panel-minItems.html
@@ -1,5 +1,5 @@
 <fieldset class="panel-wrapper field-panel1 field-wrapper" data-id="uniqueId" id="uniqueId" name="panel1">
-  <div data-min="2" data-max="-1" data-variant="addRemoveButtons" data-repeat-add-button-label="Add" data-repeat-delete-button-label="Remove" class="repeat-wrapper">
+  <div data-min="2" data-max="-1" data-variant="addDeleteButtons" data-repeat-add-button-label="Add" data-repeat-delete-button-label="Remove" class="repeat-wrapper">
     <fieldset data-min="2" data-max="-1" class="panel-wrapper field-wrapper" name="undefined"
       data-id="panel1"
       id="panel1"

--- a/test/unit/fixtures/form/doc-fieldset.html
+++ b/test/unit/fixtures/form/doc-fieldset.html
@@ -1,5 +1,5 @@
 <form data-action="undefined" novalidate="" data-redirect-url="" data-thank-you-msg="" data-source="sheet" data-rules="false" data-id="undefined">
-  <div data-min="0" data-max="undefined" data-variant="addRemoveButtons" data-repeat-add-button-label="Add" data-repeat-delete-button-label="Remove" class="repeat-wrapper">
+  <div data-min="0" data-max="undefined" data-variant="addDeleteButtons" data-repeat-add-button-label="Add" data-repeat-delete-button-label="Remove" class="repeat-wrapper">
     <fieldset class="panel-wrapper field-panel1 field-wrapper" data-id="panel1" id="panel1" name="panel1" data-repeatable="true" data-index="0">
       <div class="text-wrapper field-f2 field-wrapper" data-fieldset="panel1" data-id="f2" data-required-error-message="Please fill in this field." data-required="false"><input type="text" id="f2" name="f2" autocomplete="off"></div>
       <div class="text-wrapper field-f1 field-wrapper" data-fieldset="panel1" data-id="f1" data-required-error-message="Please fill in this field." data-required="false"><input type="text" id="f1" name="f1" autocomplete="off"></div>

--- a/test/unit/fixtures/form/enquire.html
+++ b/test/unit/fixtures/form/enquire.html
@@ -663,7 +663,7 @@
         </div>
         <div class="range-wrapper field-quote-tripcostamount field-wrapper" data-id="quote-tripcostamount" data-required-error-message="Please fill in this field." data-required="false"><label for="quote-tripcostamount" class="field-label">Total Trip Cost</label><input type="range" max="9" min="1" step="1" id="quote-tripcostamount" name="quote[tripCostAmount]" autocomplete="off"></div>
         <div class="date-wrapper field-quote-initialtrippaymentdate field-wrapper" data-id="quote-initialtrippaymentdate" data-required-error-message="Please fill in this field." data-required="false"><label for="quote-initialtrippaymentdate" class="field-label">Initial Trip Payment Date</label><input type="date" id="quote-initialtrippaymentdate" name="quote[initialTripPaymentDate]" autocomplete="off"></div>
-        <div data-min="1" data-max="3" data-variant="addRemoveButtons" data-repeat-add-button-label="Add" data-repeat-delete-button-label="Remove" class="repeat-wrapper">
+        <div data-min="1" data-max="3" data-variant="addDeleteButtons" data-repeat-add-button-label="Add" data-repeat-delete-button-label="Remove" class="repeat-wrapper">
                 <fieldset class="panel-wrapper field-traveler field-wrapper" data-id="traveler" id="traveler" name="traveler" data-max="3" data-min="1" data-repeatable="true" data-index="0">
                         <legend for="traveler" class="field-label">Traveler Info</legend>
                         <div class="text-wrapper field-name field-wrapper" data-fieldset="traveler" data-id="name" data-required-error-message="Please fill in this field." data-required="false"><label for="name" class="field-label">Name</label><input type="text" id="name" name="name" autocomplete="off"></div>


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):
2 smaller issues clubbed:
- Repeatable panle default button rendition was "Remove" and needed to be "Deleted" as provided in the default.
- Date input was misnamed as Date picker
Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://ue-bugs--aem-boilerplate-forms--adobe-rnd.hlx.live/
