### PR TITLE
UE: Fixing Buttons in Wizard not visible nor editable in content tree

### DIFF
--- a/blocks/form/components/wizard/wizard.js
+++ b/blocks/form/components/wizard/wizard.js
@@ -169,12 +169,12 @@ export class WizardLayout {
 
     const resetBtn = panel.querySelector('.reset-wrapper');
     if (resetBtn) {
-      wrapper.append(resetBtn);
+      panel.append(resetBtn);
     }
 
     const submitBtn = panel.querySelector('.submit-wrapper');
     if (submitBtn) {
-      wrapper.append(submitBtn);
+      panel.append(submitBtn);
     }
     this.assignIndexToSteps(panel);
     panel.append(wrapper);

--- a/test/unit/fixtures/form/claim.html
+++ b/test/unit/fixtures/form/claim.html
@@ -309,12 +309,12 @@
     <fieldset class="panel-wrapper field-panel-5 field-wrapper" data-id="panelcontainer-1b66045361" id="panelcontainer-1b66045361" name="panel_5"
         data-index="4" style="--wizard-step-index: 4;">
     </fieldset>
+    <div class="button-wrapper field-reset1713344016774 field-wrapper reset-wrapper" data-id="reset-0d74964a9e">
+        <button type="reset" class="button" id="reset-0d74964a9e" name="reset1713344016774">Reset</button></div>
     <div class="wizard-button-wrapper">
         <div class="button-wrapper field-back field-wrapper wizard-button-prev" data-id="wizard-button-prev"><button type="button"
                 class="button" id="wizard-button-prev" name="back">Back</button></div>
         <div class="button-wrapper field-next field-wrapper wizard-button-next" data-id="wizard-button-next"><button type="button"
                 class="button" id="wizard-button-next" name="next">Next</button></div>
-        <div class="button-wrapper field-reset1713344016774 field-wrapper reset-wrapper" data-id="reset-0d74964a9e">
-                <button type="reset" class="button" id="reset-0d74964a9e" name="reset1713344016774">Reset</button></div>
     </div>
 </fieldset>

--- a/test/unit/fixtures/form/docBasedWizardForm.html
+++ b/test/unit/fixtures/form/docBasedWizardForm.html
@@ -38,10 +38,10 @@
             <div class="hidden-wrapper field-wrapper" data-fieldset="panel-4" data-id="" data-required-error-message="Please fill in this field." data-required="false"><label for="" class="field-label">I would like to receive Shred-it emails</label><input type="hidden" id="" name="undefined" autocomplete="off" value=""></div>
             <div class="checkbox-wrapper field-newslettersignup field-wrapper" data-fieldset="panel-4" data-id="newslettersignup" data-required-error-message="Please fill in this field." data-required="false"><input type="checkbox" value="true" id="newslettersignup" name="newslettersignup" autocomplete="off"><label for="newslettersignup" class="field-label">I would like to receive Shred-it emails</label></div>
         </fieldset>
+        <div class="button-wrapper field-submitbutton field-wrapper submit-wrapper" data-fieldset="panel-4" data-id="submitbutton"><button type="submit" class="button" id="submitbutton" name="submitbutton">Submit</button></div>
         <div class="wizard-button-wrapper">
             <div class="button-wrapper field-back field-wrapper wizard-button-prev" data-id="wizard-button-prev"><button type="button" class="button" id="wizard-button-prev" name="back">Back</button></div>
             <div class="button-wrapper field-next field-wrapper wizard-button-next" data-id="wizard-button-next"><button type="button" class="button" id="wizard-button-next" name="next">Next</button></div>
-            <div class="button-wrapper field-submitbutton field-wrapper submit-wrapper" data-fieldset="panel-4" data-id="submitbutton"><button type="submit" class="button" id="submitbutton" name="submitbutton">Submit</button></div>
         </div>
     </fieldset>
     <div class="hidden-wrapper field-webform-identifier field-wrapper" data-id="webform-identifier" data-required-error-message="Please fill in this field." data-required="false"><label for="webform-identifier" class="field-label">Webform_Identifier</label><input type="hidden" id="webform-identifier" name="Webform_Identifier" autocomplete="off" value="CUSIT"></div>


### PR DESCRIPTION
Reset and submit buttons in wizard will now be editable through canvas but will still be appended to the bottom of the wizard if inserted inside any internal panel.

Jira: https://jira.corp.adobe.com/browse/FORMS-15648
Authoring test: https://author-p133911-e1313554.adobeaemcloud.com/ui#/@formsinternal01/aem/universal-editor/canvas/author-p133911-e1313554.adobeaemcloud.com/content/forms/af/bugsfinding.html?ref=ue-wizard-buttons

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.hlx.live/
- After: https://ue-wizard-buttons--aem-boilerplate-forms--adobe-rnd.hlx.live/
