### PR TITLE
fix reset wizard for doc based forms

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -456,7 +456,7 @@ export async function createForm(formDef, data) {
 
   form.addEventListener('reset', async () => {
     const newForm = await createForm(formDef);
-    document.querySelector(`[data-action="${formDef.action}"]`).replaceWith(newForm);
+    document.querySelector(`[data-action="${form?.dataset?.action}"]`).replaceWith(newForm);
   });
 
   form.addEventListener('submit', (e) => {

--- a/test/e2e/utils.js
+++ b/test/e2e/utils.js
@@ -42,8 +42,14 @@ export async function fillField(page, componentTitle, inputValues) {
 }
 
 const getCurrentBranch = () => executeGitCommand('git rev-parse --abbrev-ref HEAD');
-const openPage = async (page, relativeURL) => {
-  const url = `https://${getCurrentBranch()}--aem-boilerplate-forms--adobe-rnd.aem.live${relativeURL}`;
+const openPage = async (page, relativeURL, type='xwalk') => {
+  let site = null
+  if(type === 'docbased') {
+    site = '--aem-boilerplate-forms-doc-based--adobe-rnd.aem.live'
+  } else if(type === 'xwalk') {
+    site = '--aem-boilerplate-forms--adobe-rnd.aem.live';
+  }
+  const url = `https://${getCurrentBranch()}${site}${relativeURL}`;
   await page.goto(url, { waitUntil: 'networkidle' });
 };
 

--- a/test/e2e/x-walk/Doc-based/checkboxGroupValidation.spec.js
+++ b/test/e2e/x-walk/Doc-based/checkboxGroupValidation.spec.js
@@ -1,4 +1,5 @@
 import { test, expect } from '../../fixtures.js';
+import {openPage} from "../../utils.js";
 
 let requestPayload = null;
 const expectedPayload = {
@@ -49,10 +50,10 @@ async function validateCheckboxOption(page, option) {
 }
 
 test.describe('Checkbox Group Validation in Doc-based Form', () => {
-  const testURL = 'https://main--aem-boilerplate-forms-doc-based--adobe-rnd.aem.live/checkboxgroupoptionvalidation';
+  const testURL = '/checkboxgroupoptionvalidation';
 
   test('Verify Payload Accuracy with Last Checkbox Option Selection', async ({ page }) => {
-    await page.goto(testURL, { waitUntil: 'load' });
+    await openPage(page, testURL, 'docbased');
     page.on('request', (request) => {
       requestPayload = request.postData();
     });
@@ -62,7 +63,7 @@ test.describe('Checkbox Group Validation in Doc-based Form', () => {
   });
 
   test('Verify Payload Accuracy with multiple Checkbox Option Selection including last option', async ({ page }) => {
-    await page.goto(testURL, { waitUntil: 'load' });
+    await openPage(page, testURL, 'docbased');
     page.on('request', (request) => {
       requestPayload = request.postData();
     });
@@ -74,7 +75,7 @@ test.describe('Checkbox Group Validation in Doc-based Form', () => {
   });
 
   test('Verify Payload Accuracy with first Checkbox Option Selection', async ({ page }) => {
-    await page.goto(testURL, { waitUntil: 'load' });
+    await openPage(page, testURL, 'docbased');
     page.on('request', (request) => {
       requestPayload = request.postData();
     });

--- a/test/e2e/x-walk/Doc-based/reset.doc.spec.js
+++ b/test/e2e/x-walk/Doc-based/reset.doc.spec.js
@@ -8,8 +8,8 @@ test.describe('Reset Doc Based', () => {
         const fName = await page.getByLabel('First Name*');
         const lName = await page.getByLabel('Last Name*');
         const email = await page.getByLabel('Work Email*');
-        const next = await page.getByLabel('Next');
-        const reset = await page.getByLabel('Reset Form');
+        const next = await page.getByRole('button', { name: 'Next' })
+        const reset = await page.getByRole('button', { name: 'Reset Form' })
         await fName.fill('abc');
         await lName.fill('abc');
         await email.fill('abc@gmail.com');
@@ -17,5 +17,8 @@ test.describe('Reset Doc Based', () => {
         await expect(page.locator('.current-wizard-step')).toHaveAttribute('data-index', '1');
         await reset.click();
         await expect(page.locator('.current-wizard-step')).toHaveAttribute('data-index', '0');
+        await expect(fName).toHaveValue('');
+        await expect(lName).toHaveValue('');
+        await expect(email).toHaveValue('');
     });
 });

--- a/test/e2e/x-walk/Doc-based/reset.doc.spec.js
+++ b/test/e2e/x-walk/Doc-based/reset.doc.spec.js
@@ -1,0 +1,21 @@
+import { test, expect } from '../../fixtures.js';
+import { openPage } from '../../utils.js';
+
+test.describe('Reset Doc Based', () => {
+    const testURL = '/reset';
+    test(':test rest for wizard', async ({ page }) => {
+        await openPage(page, testURL, 'docbased');
+        const fName = await page.getByLabel('First Name*');
+        const lName = await page.getByLabel('Last Name*');
+        const email = await page.getByLabel('Work Email*');
+        const next = await page.getByLabel('Next');
+        const reset = await page.getByLabel('Reset Form');
+        await fName.fill('abc');
+        await lName.fill('abc');
+        await email.fill('abc@gmail.com');
+        await next.click();
+        await expect(page.locator('.current-wizard-step')).toHaveAttribute('data-index', '1');
+        await reset.click();
+        await expect(page.locator('.current-wizard-step')).toHaveAttribute('data-index', '0');
+    });
+});

--- a/test/e2e/x-walk/Doc-based/submissionValidation.spec.js
+++ b/test/e2e/x-walk/Doc-based/submissionValidation.spec.js
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures.js';
-import { fillField } from '../../utils.js';
+import {fillField, openPage} from '../../utils.js';
 
 const inputValues = {
   textInput: 'adobe',
@@ -27,10 +27,10 @@ const titles = ['Text Input', 'Check Box Group', 'Number Input', 'Radio Button',
 let requestPayload = null;
 
 test.describe('Form Rendering and Submission Validation', async () => {
-  const testURL = 'https://main--aem-boilerplate-forms-doc-based--adobe-rnd.aem.page/submissionvalidation';
+  const testURL = '/submissionvalidation';
 
   test('Validate Doc-Based Form components and submission payload @chromium-only', async ({ page }) => {
-    await page.goto(testURL, { waitUntil: 'load' });
+    await openPage(page, testURL, 'docbased');
     await expect(page.getByLabel('Text Input')).toBeVisible();
 
     // listeners to fetch payload form submission.


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms-doc-based--adobe-rnd.aem.live/reset
- After: https://reset--aem-boilerplate-forms-doc-based--adobe-rnd.aem.live/reset
