### PR TITLE
feat: add support for enable and readonly for rating component.

### DIFF
--- a/blocks/form/components/rating/rating.css
+++ b/blocks/form/components/rating/rating.css
@@ -9,6 +9,10 @@ main .form .rating .star {
     cursor: pointer;
 }
 
+main .form .rating.disabled .star {
+    cursor: not-allowed;
+}
+
 main .form .rating .star.selected {
     color: #f8d053;
 }
@@ -17,6 +21,6 @@ main .form .rating:hover .star.hover {
     color: #ecba24;
 }
 
-main .form .rating.disabled .star.selected {
+main .form .rating.disabled .star:not(.selected) {
     color: #ccc;
 }

--- a/blocks/form/components/rating/rating.css
+++ b/blocks/form/components/rating/rating.css
@@ -16,3 +16,7 @@ main .form .rating .star.selected {
 main .form .rating:hover .star.hover {
     color: #ecba24;
 }
+
+main .form .rating.disabled .star.selected {
+    color: #ccc;
+}

--- a/blocks/form/components/rating/rating.js
+++ b/blocks/form/components/rating/rating.js
@@ -15,9 +15,12 @@
 // the function will also add a mouseover event listener to the star element
 // when a star element is hovered, a css hover class will be added to the star
 // elements till the index of the hovered star element
-export default function decorate(fieldDiv) {
+export default function decorate(fieldDiv, fieldJson) {
   // get the input element from the fieldDiv
   const input = fieldDiv.querySelector('input[type="number"]');
+  const enabled = fieldJson?.enabled !== false; // Default to true if not specified
+  const readOnly = fieldJson?.readOnly === true; // Default to false if not specified
+  
   // get the max attribute from the input element
   let max = input.getAttribute('max');
   if (!max) {
@@ -27,8 +30,13 @@ export default function decorate(fieldDiv) {
   const ratingDiv = document.createElement('div');
   // add the rating class to the rating div
   ratingDiv.classList.add('rating');
-  // add the hover class to the rating div
   ratingDiv.classList.add('hover');
+
+  // Add disabled class if the component is not enabled or is readonly
+  if (!enabled || readOnly) {
+    ratingDiv.classList.add('disabled');
+  }
+
   // create a star element for each value from 1 to max
   for (let i = 1; i <= max; i += 1) {
     // create a star element
@@ -39,64 +47,77 @@ export default function decorate(fieldDiv) {
     star.textContent = '★';
     // add the star element to the rating div
     ratingDiv.appendChild(star);
+
     // add a click event listener to the star element
     star.addEventListener('click', () => {
-      // set the value of the input element to the index of the star element
-      input.value = i;
-      // trigger a change event that bubbles on the input element
-      input.dispatchEvent(new Event('change', { bubbles: true }));
-      // add the selected class to the star elements till the index of the clicked star element
-      for (let j = 0; j < i; j += 1) {
-        ratingDiv.children[j].classList.add('selected');
-      }
-      // remove the selected class from the star elements after the index of the
-      // clicked star element
-      for (let j = i; j < max; j += 1) {
-        ratingDiv.children[j].classList.remove('selected');
+      // Only process click if the component is not disabled
+      if (!ratingDiv.classList.contains('disabled')) {
+        // set the value of the input element to the index of the star element
+        input.value = i;
+        // trigger a change event that bubbles on the input element
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+        // add the selected class to the star elements till the index of the clicked star element
+        for (let j = 0; j < i; j += 1) {
+          ratingDiv.children[j].classList.add('selected');
+        }
+        // remove the selected class from the star elements after the index of the
+        // clicked star element
+        for (let j = i; j < max; j += 1) {
+          ratingDiv.children[j].classList.remove('selected');
+        }
       }
     });
+
     // add a mouseover event listener to the star element
     star.addEventListener('mouseover', () => {
-      // add the css hover class to the star
-      // elements till the index of the hovered star element
-      // and remove the css hover class from the star
-      // elements after the index of the hovered star element
-      for (let j = 0; j < i; j += 1) {
-        ratingDiv.children[j].classList.add('hover');
-      }
-      for (let j = i; j < max; j += 1) {
-        ratingDiv.children[j].classList.remove('hover');
-      }
-    });
-    // show an emoji in the emoji element when the star element is hovered
-    // if the index of star element is less than or equal to 3 show sad emoji
-    // if the index of star element is greater than 3 show happy emoji
-    star.addEventListener('mouseover', () => {
-      const emojiElement = ratingDiv.querySelector('.emoji');
-      if (i <= 3) {
-        emojiElement.textContent = '😢';
-      } else {
-        emojiElement.textContent = '😊';
+      // Only process hover if the component is not disabled
+      if (!ratingDiv.classList.contains('disabled')) {
+        // add the css hover class to the star
+        // elements till the index of the hovered star element
+        // and remove the css hover class from the star
+        // elements after the index of the hovered star element
+        for (let j = 0; j < i; j += 1) {
+          ratingDiv.children[j].classList.add('hover');
+        }
+        for (let j = i; j < max; j += 1) {
+          ratingDiv.children[j].classList.remove('hover');
+        }
+
+        // show an emoji in the emoji element when the star element is hovered
+        // if the index of star element is less than or equal to 3 show sad emoji
+        // if the index of star element is greater than 3 show happy emoji
+        const emojiElement = ratingDiv.querySelector('.emoji');
+        if (i <= 3) {
+          emojiElement.textContent = '😢';
+        } else {
+          emojiElement.textContent = '😊';
+        }
       }
     });
   }
+
   // add the emoji element next to the last star element
   const emoji = document.createElement('span');
   emoji.classList.add('emoji');
   ratingDiv.appendChild(emoji);
+
   // add a mouseleave event listener to the rating div
   ratingDiv.addEventListener('mouseleave', () => {
-    // check if no star is selected
-    if (!ratingDiv.querySelector('.selected')) {
-      // remove the hover class from the star elements
-      for (let j = 0; j < max; j += 1) {
-        ratingDiv.children[j].classList.remove('hover');
+    // Only process mouseleave if the component is not disabled
+    if (!ratingDiv.classList.contains('disabled')) {
+      // check if no star is selected
+      if (!ratingDiv.querySelector('.selected')) {
+        // remove the hover class from the star elements
+        for (let j = 0; j < max; j += 1) {
+          ratingDiv.children[j].classList.remove('hover');
+        }
+        // remove the emoji from the emoji element
+        const emojiElement = ratingDiv.querySelector('.emoji');
+        emojiElement.textContent = '';
       }
-      // remove the emoji from the emoji element
-      const emojiElement = ratingDiv.querySelector('.emoji');
-      emojiElement.textContent = '';
     }
   });
+
   // add the rating div to the fieldDiv
   fieldDiv.appendChild(ratingDiv);
   // hide the input element

--- a/blocks/form/components/rating/rating.js
+++ b/blocks/form/components/rating/rating.js
@@ -18,9 +18,9 @@
 export default function decorate(fieldDiv, fieldJson) {
   // get the input element from the fieldDiv
   const input = fieldDiv.querySelector('input[type="number"]');
-  const enabled = fieldJson?.enabled !== false; // Default to true if not specified
-  const readOnly = fieldJson?.readOnly === true; // Default to false if not specified
-  
+  const enabled = fieldJson?.enabled;
+  const readOnly = fieldJson?.readOnly;
+
   // get the max attribute from the input element
   let max = input.getAttribute('max');
   if (!max) {

--- a/blocks/form/rules/index.js
+++ b/blocks/form/rules/index.js
@@ -59,7 +59,7 @@ function handleActiveChild(id, form) {
 async function fieldChanged(payload, form, generateFormRendition) {
   const { changes, field: fieldModel } = payload;
   const {
-    id, name, fieldType, readOnly, type, displayValue, displayFormat, displayValueExpression,
+    id, name, fieldType, ':type': componentType, readOnly, type, displayValue, displayFormat, displayValueExpression,
     activeChild,
   } = fieldModel;
   const field = form.querySelector(`#${id}`);
@@ -133,6 +133,10 @@ async function fieldChanged(payload, form, generateFormRendition) {
           if (readOnly === false) {
             disableElement(field, !currentValue);
           }
+        } else if (componentType === 'rating') {
+          if (readOnly === false) {
+            fieldWrapper.querySelector('.rating')?.classList.toggle('disabled', !currentValue);
+          }
         } else {
           field.toggleAttribute('disabled', currentValue === false);
         }
@@ -144,6 +148,8 @@ async function fieldChanged(payload, form, generateFormRendition) {
           });
         } else if (fieldType === 'drop-down') {
           disableElement(field, currentValue);
+        } else if (componentType === 'rating') {
+          fieldWrapper.querySelector('.rating')?.classList.toggle('disabled', currentValue === true);
         } else {
           field.toggleAttribute('disabled', currentValue === true);
         }

--- a/test/e2e/x-walk/rating.spec.js
+++ b/test/e2e/x-walk/rating.spec.js
@@ -1,5 +1,5 @@
-import { test, expect } from '../../fixtures.js';
-import { openPage } from '../../utils.js';
+import { test, expect } from '../fixtures.js';
+import { openPage } from '../utils.js';
 
 const emoji = ['😢', '😊'];
 let rating = null;
@@ -14,7 +14,7 @@ const selector = {
 const partialUrl = '/L2NvbnRlbnQvcmF0aW5nQ29tcG9uZW50VGVzdENvbGxhdGVyYWwvaW5kZXgvamNyOmNvbnRlbnQvcm9vdC9zZWN0aW9uXzAvZm9ybQ==';
 const starsSelected = 'star hover selected';
 
-test.describe('custom component validation', () => {
+test.describe('rating component validation', () => {
   const testURL = '/content/aem-boilerplate-forms-xwalk-collaterals/rating-component';
 
   test('rating custom component validation @chromium-only', async ({ page }) => {
@@ -52,5 +52,64 @@ test.describe('custom component validation', () => {
     }
     await page.getByRole('button', { name: 'Submit' }).click();
     expect(requestPayload.includes(rating)).toBeTruthy();
+  });
+
+  test('test enable disable', async ({page}) => {
+    await openPage(page, testURL);
+
+    // Test initial state (enabled)
+    const ratingComponent = page.locator('.rating');
+    await expect(ratingComponent).not.toHaveClass(/disabled/);
+
+    // Click on the third star
+    const stars = page.locator('.star');
+    await stars.nth(2).click();
+
+    // Verify the first three stars have the 'selected' class
+    for (let i = 0; i < 3; i++) {
+      await expect(stars.nth(i)).toHaveClass(/selected/);
+    }
+
+    // Verify the remaining stars don't have the 'selected' class
+    const totalStars = await stars.count();
+    for (let i = 3; i < totalStars; i++) {
+      await expect(stars.nth(i)).not.toHaveClass(/selected/);
+    }
+
+    // Disable the rating component
+    const disableBtn = await page.getByRole('button', { name: 'disable' });
+    await disableBtn.click();
+
+    // Verify the component has the 'disabled' class
+    await expect(ratingComponent).toHaveClass(/disabled/);
+
+    // Try to click on a different star (should not change the selection)
+    await stars.nth(4).click();
+
+    // Verify the selection hasn't changed (still only first three stars selected)
+    for (let i = 0; i < 3; i++) {
+      await expect(stars.nth(i)).toHaveClass(/selected/);
+    }
+    for (let i = 3; i < totalStars; i++) {
+      await expect(stars.nth(i)).not.toHaveClass(/selected/);
+    }
+
+    // Re-enable the component
+    const enableBtn = await page.getByRole('button', { name: 'enable' });
+    await enableBtn.click();
+
+    // Verify the component doesn't have the 'disabled' class
+    await expect(ratingComponent).not.toHaveClass(/disabled/);
+
+    // Click on a different star
+    await stars.nth(4).click();
+
+    // Verify the selection has changed
+    for (let i = 0; i < 5; i++) {
+      await expect(stars.nth(i)).toHaveClass(/selected/);
+    }
+    for (let i = 5; i < totalStars; i++) {
+      await expect(stars.nth(i)).not.toHaveClass(/selected/);
+    }
   });
 });

--- a/test/unit/fixtures/components/rating/rating.html
+++ b/test/unit/fixtures/components/rating/rating.html
@@ -1,7 +1,7 @@
 <div class="number-wrapper field-numberinput-13917802541727686782114 field-wrapper" data-id="numberinput-c9a02f4cd1" data-required="false" data-description="<p>This is a help text.</p>" data-component-status="loaded">
     <label for="numberinput-c9a02f4cd1" class="field-label">Rating</label>
-    <input type="number" id="numberinput-c9a02f4cd1" name="numberinput_13917802541727686782114" aria-describedby="numberinput-c9a02f4cd1-description" autocomplete="off" style="display: none;" />
-    <div class="rating hover">
+    <input type="number" id="numberinput-c9a02f4cd1" name="numberinput_13917802541727686782114" disabled aria-describedby="numberinput-c9a02f4cd1-description" autocomplete="off" style="display: none;" />
+    <div class="rating hover disabled">
         <span class="star">★</span>
         <span class="star">★</span>
         <span class="star">★</span>

--- a/test/unit/fixtures/components/rating/rating.js
+++ b/test/unit/fixtures/components/rating/rating.js
@@ -7,7 +7,7 @@ export const fieldDef = {
     visible: true,
     type: 'number',
     required: false,
-    enabled: true,
+    enabled: false,
     readOnly: false,
     description: '<p>This is a help text.</p>',
     label: {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-boilerplate-forms--adobe-rnd.aem.page/content/aem-boilerplate-forms-xwalk-collaterals/rating-component
- After: https://rating--aem-boilerplate-forms--adobe-rnd.aem.page/content/aem-boilerplate-forms-xwalk-collaterals/rating-component
